### PR TITLE
refactor(u1-image-base): unify image download via presigned OSS URL flow

### DIFF
--- a/skills/u1-image-base/u1_image_base/generation/core/__init__.py
+++ b/skills/u1-image-base/u1_image_base/generation/core/__init__.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 import httpx
 
 from u1_image_base.u1_api.paths import (
-    generation_file_download_url,
     generation_file_presigned_url,
     generation_file_upload_url,
 )
@@ -106,7 +105,8 @@ async def download_image(
         headers (dict[str, str]):
             HTTP headers including authentication.
         image_ref (str):
-            The image reference (URL or cached file key) to download.
+            Absolute URL to download directly, or OSS key (fetches presigned URL
+            then downloads; no fallback to direct files API).
         output_path (Path):
             The local file path where the image will be saved.
 
@@ -117,8 +117,14 @@ async def download_image(
     if is_absolute_url(image_ref):
         response = await client.get(image_ref, headers=headers)
     else:
-        download_url = generation_file_download_url(base_url, image_ref)
-        response = await client.get(download_url, headers=headers)
+        # Presigned OSS GET must not use the same AsyncClient default headers as API
+        # calls (e.g. Content-Type: application/json), or the OSS signature will not match.
+        presigned_url = await generate_presigned_url(client, base_url, headers, image_ref)
+        async with httpx.AsyncClient(
+            timeout=client.timeout,
+            trust_env=True,
+        ) as fetch_client:
+            response = await fetch_client.get(presigned_url)
     response.raise_for_status()
     output_path.write_bytes(response.content)
     return output_path

--- a/skills/u1-image-base/u1_image_base/image_edit/image_edit.py
+++ b/skills/u1-image-base/u1_image_base/image_edit/image_edit.py
@@ -12,14 +12,16 @@ import asyncio
 import json
 import sys
 from pathlib import Path
-from urllib.parse import quote, urlparse
 
 import httpx
 
 from u1_image_base.configs import global_configs
+from u1_image_base.generation.core import (
+    download_image,
+    ensure_output_path,
+    resolve_image_ref,
+)
 from u1_image_base.u1_api.paths import (
-    generation_file_presigned_url,
-    generation_file_upload_url,
     image_edit_create_url,
     image_edit_status_url,
 )
@@ -51,51 +53,6 @@ def build_headers(api_key: str) -> dict[str, str]:
             Headers dictionary with Authorization set to the api_key.
     """
     return {"Authorization": api_key}
-
-
-def ensure_output_path(path: Path) -> Path:
-    """Ensure the parent directory of the given path exists.
-
-    Args:
-        path (Path):
-            The file path whose parent directory should be created.
-
-    Returns:
-        Path:
-            The original path unchanged.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def is_absolute_url(value: str) -> bool:
-    """Check if the given value is an absolute URL.
-
-    Args:
-        value (str):
-            The string to check.
-
-    Returns:
-        bool:
-            True if value contains both a scheme (e.g., "http") and
-            a network location (netloc), False otherwise.
-    """
-    parsed = urlparse(value)
-    return bool(parsed.scheme and parsed.netloc)
-
-
-def is_local_file(value: str) -> bool:
-    """Check if the given value is a path to a local file.
-
-    Args:
-        value (str):
-            The file path to check.
-
-    Returns:
-        bool:
-            True if value points to an existing local file, False otherwise.
-    """
-    return Path(value).is_file()
 
 
 def extract_task_input(task: dict) -> dict:
@@ -132,153 +89,6 @@ def extract_task_image(task: dict) -> dict | None:
     if isinstance(image, dict) and image.get("url"):
         return image
     return None
-
-
-async def upload_local_image(
-    client: httpx.AsyncClient,
-    base_url: str,
-    headers: dict[str, str],
-    image_path: Path,
-) -> str:
-    """Upload a local image file to the generation service.
-
-    Args:
-        client (httpx.AsyncClient):
-            The HTTP client for making requests.
-        base_url (str):
-            The API base URL.
-        headers (dict[str, str]):
-            HTTP headers including authentication.
-        image_path (Path):
-            Path to the local image file to upload.
-
-    Returns:
-        str:
-            The OSS path returned by the server after successful upload.
-
-    Raises:
-        ValueError:
-            If the server response is not a non-empty string.
-    """
-    with open(image_path, "rb") as image_file:
-        response = await client.post(
-            generation_file_upload_url(base_url),
-            headers=headers,
-            files={"upload_file": (image_path.name, image_file)},
-        )
-    response.raise_for_status()
-    body = response.json()
-    if not isinstance(body, str) or not body:
-        raise ValueError(f"unexpected upload response: {body}")
-    return body
-
-
-async def generate_presigned_url(
-    client: httpx.AsyncClient,
-    base_url: str,
-    headers: dict[str, str],
-    oss_path: str,
-) -> str:
-    """Generate a presigned URL for accessing an OSS file.
-
-    Args:
-        client (httpx.AsyncClient):
-            The HTTP client for making requests.
-        base_url (str):
-            The API base URL.
-        headers (dict[str, str]):
-            HTTP headers including authentication.
-        oss_path (str):
-            The OSS file path for which to generate a presigned URL.
-
-    Returns:
-        str:
-            The presigned URL for accessing the file.
-
-    Raises:
-        ValueError:
-            If the server response is not a non-empty string.
-    """
-    response = await client.get(
-        generation_file_presigned_url(base_url),
-        headers=headers,
-        params={"oss_path": oss_path},
-    )
-    response.raise_for_status()
-    body = response.json()
-    if not isinstance(body, str) or not body:
-        raise ValueError(f"unexpected presigned url response: {body}")
-    return body
-
-
-async def resolve_image_ref(
-    client: httpx.AsyncClient,
-    base_url: str,
-    headers: dict[str, str],
-    image_value: str,
-) -> str:
-    """Resolve an image reference to a URL.
-
-    Args:
-        client (httpx.AsyncClient):
-            The HTTP client for making requests.
-        base_url (str):
-            The API base URL.
-        headers (dict[str, str]):
-            HTTP headers including authentication.
-        image_value (str):
-            An image reference: absolute URL, local file path, or cached key.
-
-    Returns:
-        str:
-            A URL suitable for use in API requests. If image_value is an
-            absolute URL, it is returned as-is. If it is a local file,
-            the file is uploaded and a presigned URL is returned.
-    """
-    if is_absolute_url(image_value):
-        return image_value
-    if is_local_file(image_value):
-        uploaded_path = await upload_local_image(client, base_url, headers, Path(image_value))
-        return await generate_presigned_url(client, base_url, headers, uploaded_path)
-    return image_value
-
-
-async def download_image(
-    client: httpx.AsyncClient,
-    base_url: str,
-    headers: dict[str, str],
-    image_ref: str,
-    output_path: Path,
-) -> Path:
-    """Download an image from a URL or image reference.
-
-    Args:
-        client (httpx.AsyncClient):
-            The HTTP client for making requests.
-        base_url (str):
-            The API base URL.
-        headers (dict[str, str]):
-            HTTP headers including authentication.
-        image_ref (str):
-            The image reference (URL or cached file key) to download.
-        output_path (Path):
-            The local file path where the image will be saved.
-
-    Returns:
-        Path:
-            The path to the downloaded image file.
-    """
-    if is_absolute_url(image_ref):
-        response = await client.get(image_ref, headers=headers)
-    else:
-        image_key = image_ref.lstrip("/")
-        response = await client.get(
-            f"{base_url}/v1/generation/files/{quote(image_key, safe='/')}",
-            headers=headers,
-        )
-    response.raise_for_status()
-    output_path.write_bytes(response.content)
-    return output_path
 
 
 class ImageEditClient:


### PR DESCRIPTION
## Summary

Refactor image download logic to use a presigned OSS URL flow and remove duplicated helper implementations in `image_edit`.

## Changes

- Update `generation/core/__init__.py` download path:
  - Keep direct GET for absolute image URLs.
  - For OSS key refs, fetch presigned URL first, then download from that URL.
- Refactor `image_edit/image_edit.py` to reuse shared helpers from `generation.core`:
  - Reuse `download_image`, `ensure_output_path`, and `resolve_image_ref`.
  - Remove redundant local helper implementations to reduce duplication.
- Keep existing response schema and output naming behavior unchanged:
  - `status/error/message/task_id/output` contract remains consistent.
  - Existing output path handling and filename conventions remain intact.

## Additional Notes

- This reduces egress pressure on direct file endpoints by switching to presigned URL based downloads.
- The branch is clean and tracks `origin/gy/image-base-file`.