### PR TITLE
refactor: improve error handling, URL validation, and response parsing in u1-image-base

### DIFF
--- a/skills/u1-image-base/ruff.toml
+++ b/skills/u1-image-base/ruff.toml
@@ -25,7 +25,7 @@ unfixable = [
     "F401", # unused imports
     "F841", # unused variables
 ]
-ignore = ["E501"]
+ignore = ["E501", "RUF067"]
 
 [lint.per-file-ignores]
 "openclaw_runner.py" = ["E402"]

--- a/skills/u1-image-base/u1_image_base/configs.py
+++ b/skills/u1-image-base/u1_image_base/configs.py
@@ -153,30 +153,36 @@ class Configs:
 
         # Check fields combination rules:
         if self.U1_IMAGE_GEN_MODEL_TYPE != "u1" and not self.U1_IMAGE_GEN_MODEL:
-            errors.append((
-                "U1_IMAGE_GEN_MODEL",
-                "U1_IMAGE_GEN_MODEL is required when U1_IMAGE_GEN_MODEL_TYPE is not 'u1'",
-            ))
+            errors.append(
+                (
+                    "U1_IMAGE_GEN_MODEL",
+                    "U1_IMAGE_GEN_MODEL is required when U1_IMAGE_GEN_MODEL_TYPE is not 'u1'",
+                )
+            )
 
         warnings: list[tuple[str, str]] = []
         vlm_keys = ("VLM_API_KEY", "VLM_BASE_URL", "VLM_MODEL", "VLM_TYPE")
-        warnings.extend([
-            (
-                key,
-                f"{key} is not set; VLM may be not available. Try setting environment variable(s): {field_env_names[key]}",
-            )
-            for key in vlm_keys
-            if not getattr(self, key)
-        ])
+        warnings.extend(
+            [
+                (
+                    key,
+                    f"{key} is not set; VLM may be not available. Try setting environment variable(s): {field_env_names[key]}",
+                )
+                for key in vlm_keys
+                if not getattr(self, key)
+            ]
+        )
         llm_keys = ("LLM_API_KEY", "LLM_BASE_URL", "LLM_MODEL", "LLM_TYPE")
-        warnings.extend([
-            (
-                key,
-                f"{key} is not set; LLM may be not available. Try setting environment variable(s): {field_env_names[key]}",
-            )
-            for key in llm_keys
-            if not getattr(self, key)
-        ])
+        warnings.extend(
+            [
+                (
+                    key,
+                    f"{key} is not set; LLM may be not available. Try setting environment variable(s): {field_env_names[key]}",
+                )
+                for key in llm_keys
+                if not getattr(self, key)
+            ]
+        )
 
         # check urls
         errors.extend(

--- a/skills/u1-image-base/u1_image_base/configs.py
+++ b/skills/u1-image-base/u1_image_base/configs.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import warnings
 from pathlib import Path
-from typing import Annotated, Literal, Optional, Union, get_args, get_origin, get_type_hints
+from typing import Annotated, Literal, get_args, get_origin, get_type_hints
 from urllib.parse import urlparse
 
 SCRIPT_DIR = Path(__file__).absolute().parent
@@ -51,10 +53,10 @@ class Field:
     __slots__ = ("env_names", "required")
 
     def __init__(self, *env_names: str, required: bool = False) -> None:
-        self.env_names: Optional[tuple[str, ...]] = tuple(env_names) if env_names else None
+        self.env_names: tuple[str, ...] | None = tuple(env_names) if env_names else None
         self.required = required
 
-    def resolve(self, target_type: Optional[type] = None) -> Union[str, int, float, None]:
+    def resolve(self, target_type: type | None = None) -> str | int | float | None:
         """Return the first env var value that is set, converted to target_type.
 
         Args:
@@ -133,7 +135,7 @@ class Configs:
                 setattr(self, field, val)
 
     def validate_configs(self) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
-        field_env_names: dict[str, Union[tuple[str, ...], str]] = {}
+        field_env_names: dict[str, tuple[str, ...] | str] = {}
         errors: list[tuple[str, str]] = []
         for field, hint in get_type_hints(type(self), include_extras=True).items():
             env_var = next((a for a in get_args(hint) if isinstance(a, Field)), None)
@@ -195,7 +197,7 @@ class Configs:
         )
         return errors, warnings
 
-    def get_annotated_field(self, field_name: str) -> Union[Field, None]:
+    def get_annotated_field(self, field_name: str) -> Field | None:
         hints = get_type_hints(type(self), include_extras=True)
         if field_name not in hints:
             return None

--- a/skills/u1-image-base/u1_image_base/configs.py
+++ b/skills/u1-image-base/u1_image_base/configs.py
@@ -1,7 +1,9 @@
+import contextlib
 import os
 import warnings
 from pathlib import Path
-from typing import Annotated, Literal, get_args, get_origin, get_type_hints
+from typing import Annotated, Literal, Optional, Union, get_args, get_origin, get_type_hints
+from urllib.parse import urlparse
 
 SCRIPT_DIR = Path(__file__).absolute().parent
 # "skills" directory that contains "u1-*" skills (e.g. "u1-image-base", "u1-infographic", etc.)
@@ -49,10 +51,10 @@ class Field:
     __slots__ = ("env_names", "required")
 
     def __init__(self, *env_names: str, required: bool = False) -> None:
-        self.env_names: tuple[str, ...] | None = tuple(env_names) if env_names else None
+        self.env_names: Optional[tuple[str, ...]] = tuple(env_names) if env_names else None
         self.required = required
 
-    def resolve(self, target_type: type | None = None) -> str | int | float | None:
+    def resolve(self, target_type: Optional[type] = None) -> Union[str, int, float, None]:
         """Return the first env var value that is set, converted to target_type.
 
         Args:
@@ -101,7 +103,7 @@ class Configs:
     # image-recognize (VLM) — falls back to shared U1_LM_* vars
     VLM_API_KEY: Annotated[str, Field("VLM_API_KEY", "U1_LM_API_KEY")] = "dummy"
     VLM_BASE_URL: Annotated[str, Field("VLM_BASE_URL", "U1_LM_BASE_URL")] = ""
-    VLM_MODEL: Annotated[str, Field("VLM_MODEL", "U1_LM_MODEL")] = "sensenova-122b-128k-step9k"
+    VLM_MODEL: Annotated[str, Field("VLM_MODEL", "U1_LM_MODEL")] = ""
     VLM_TYPE: Annotated[
         Literal["anthropic-messages", "openai-completions"],
         Field("VLM_TYPE", "U1_LM_TYPE"),
@@ -110,7 +112,7 @@ class Configs:
     # text-optimize (LLM) — falls back to shared U1_LM_* vars
     LLM_API_KEY: Annotated[str, Field("LLM_API_KEY", "U1_LM_API_KEY")] = "dummy"
     LLM_BASE_URL: Annotated[str, Field("LLM_BASE_URL", "U1_LM_BASE_URL")] = ""
-    LLM_MODEL: Annotated[str, Field("LLM_MODEL", "U1_LM_MODEL")] = "sensenova-122b-128k-step9k"
+    LLM_MODEL: Annotated[str, Field("LLM_MODEL", "U1_LM_MODEL")] = ""
     LLM_TYPE: Annotated[
         Literal["anthropic-messages", "openai-completions"],
         Field("LLM_TYPE", "U1_LM_TYPE"),
@@ -131,7 +133,7 @@ class Configs:
                 setattr(self, field, val)
 
     def validate_configs(self) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
-        field_env_names: dict[str, tuple[str, ...] | str] = {}
+        field_env_names: dict[str, Union[tuple[str, ...], str]] = {}
         errors: list[tuple[str, str]] = []
         for field, hint in get_type_hints(type(self), include_extras=True).items():
             env_var = next((a for a in get_args(hint) if isinstance(a, Field)), None)
@@ -175,7 +177,25 @@ class Configs:
             for key in llm_keys
             if not getattr(self, key)
         ])
+
+        # check urls
+        errors.extend(
+            (
+                key,
+                f"{key} is not a valid base URL: {getattr(self, key)}",
+            )
+            for key in ("VLM_BASE_URL", "LLM_BASE_URL")
+            if getattr(self, key) and not is_valid_base_url(getattr(self, key))
+        )
         return errors, warnings
+
+    def get_annotated_field(self, field_name: str) -> Union[Field, None]:
+        hints = get_type_hints(type(self), include_extras=True)
+        if field_name not in hints:
+            return None
+        hint = hints[field_name]
+        field_inst = next((a for a in get_args(hint) if isinstance(a, Field)), None)
+        return field_inst
 
     def get_env_var_help(self, field_name: str) -> str:
         """Return a help string describing which environment variables can be used
@@ -191,18 +211,12 @@ class Configs:
         if not hasattr(type(self), field_name):
             return f"Field '{field_name}' does not exist in Configs."
 
-        hints = get_type_hints(type(self), include_extras=True)
-        if field_name not in hints:
-            return f"Field '{field_name}' has no type hint."
-
-        hint = hints[field_name]
-        env_var = next((a for a in get_args(hint) if isinstance(a, Field)), None)
-        if env_var is None:
+        field_inst = self.get_annotated_field(field_name)
+        if field_inst is None:
             return f"Field '{field_name}' is not configurable via environment variables."
 
         current_value = getattr(self, field_name)
-        env_names = list(env_var.env_names) if env_var.env_names else []
-
+        env_names = list(field_inst.env_names) if field_inst.env_names else []
         if len(env_names) == 1:
             return (
                 f"To set '{field_name}', configure the environment variable: {env_names[0]}\n"
@@ -215,6 +229,13 @@ class Configs:
                 f"They are tried in order; the first set value is used.\n"
                 f"Current value: {current_value!r}"
             )
+
+
+def is_valid_base_url(url: str) -> bool:
+    with contextlib.suppress(ValueError):
+        parsed = urlparse(url)
+        return bool(parsed.scheme and parsed.netloc)
+    return False
 
 
 def reload_env(override: bool = True) -> None:

--- a/skills/u1-image-base/u1_image_base/configs.py
+++ b/skills/u1-image-base/u1_image_base/configs.py
@@ -90,7 +90,7 @@ class Configs:
     U1_API_KEY: Annotated[str, Field("U1_API_KEY", required=True)] = ""
     U1_IMAGE_GEN_BASE_URL: Annotated[
         str, Field("U1_IMAGE_GEN_BASE_URL", "U1_BASE_URL", required=True)
-    ] = "https://u1-api.sensenova.cn/zoe-model"
+    ] = "https://u1-api.sensenova.cn/model"
     # if U1_IMAGE_GEN_MODEL_TYPE is not "u1", U1_IMAGE_GEN_MODEL must be set
     #   "nano-banana": available models are "gemini-3.1-flash-image-preview", "gemini-3-pro-image-preview"
     U1_IMAGE_GEN_MODEL_TYPE: Annotated[

--- a/skills/u1-image-base/u1_image_base/exceptions.py
+++ b/skills/u1-image-base/u1_image_base/exceptions.py
@@ -1,5 +1,7 @@
 """Shared exceptions for u1-image-base."""
 
+from __future__ import annotations
+
 
 class U1BaseError(Exception):
     """Base exception for u1-image-base."""

--- a/skills/u1-image-base/u1_image_base/generation/core/__init__.py
+++ b/skills/u1-image-base/u1_image_base/generation/core/__init__.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 from urllib.parse import urlparse
 
 import httpx
@@ -71,7 +72,7 @@ def extract_task_input(task: dict) -> dict:
     }
 
 
-def extract_task_image(task: dict) -> Union[dict, None]:
+def extract_task_image(task: dict) -> dict | None:
     """Extract the image result from a completed task.
 
     Args:

--- a/skills/u1-image-base/u1_image_base/generation/core/__init__.py
+++ b/skills/u1-image-base/u1_image_base/generation/core/__init__.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union
 from urllib.parse import urlparse
 
 import httpx
@@ -70,7 +71,7 @@ def extract_task_input(task: dict) -> dict:
     }
 
 
-def extract_task_image(task: dict) -> dict | None:
+def extract_task_image(task: dict) -> Union[dict, None]:
     """Extract the image result from a completed task.
 
     Args:

--- a/skills/u1-image-base/u1_image_base/generation/nano_banana.py
+++ b/skills/u1-image-base/u1_image_base/generation/nano_banana.py
@@ -8,8 +8,8 @@ from typing import Any, Literal
 import httpx
 from typing_extensions import override
 
-from u1_image_base.configs import global_configs
-from u1_image_base.utils.error_utils import U1HttpErrorBase
+from u1_image_base.configs import global_configs, is_valid_base_url
+from u1_image_base.utils.error_utils import U1HttpErrorBase, U1HttpNotFoundError
 
 from .core import ensure_output_path
 from .core.client_base import DEFAULT_HTTP_REQUEST_TIMEOUT, DEFAULT_MAX_CONNECTIONS, T2IBaseClient
@@ -123,10 +123,28 @@ class NanoBananaText2ImageClient(T2IBaseClient):
             )
             data = self.parse_response(create_response)
         except U1HttpErrorBase as exc:
+            details = exc.detail or ""
+            field_name = None
+            if exc.code == 404:
+                field_name = "U1_IMAGE_GEN_BASE_URL"
+            elif exc.code == 401:
+                field_name = "U1_API_KEY"
+            if field_name is not None:
+                field_hint = global_configs.get_annotated_field(field_name)
+                if field_hint is not None:
+                    env_names = list(field_hint.env_names) if field_hint.env_names else []
+                    if env_names:
+                        if len(env_names) == 1:
+                            details += (
+                                f"Is the environment variable `{env_names[0]}` set correctly?"
+                            )
+                        else:
+                            env_names_str = ", ".join([f"`{n}`" for n in env_names])
+                            details += f"Is any of the following environment variable(s) set correctly: {env_names_str}?"
             return {
                 "status": "failed",
                 "error": f"HTTP {exc.code}: {exc.message}",
-                "message": exc.detail,
+                "message": details,
             }
         try:
             images = data["images"]
@@ -178,13 +196,17 @@ class NanoBananaText2ImageClient(T2IBaseClient):
                     global_configs.get_env_var_help("U1_IMAGE_GEN_BASE_URL")
                 )
             )
+        if not is_valid_base_url(base_url):
+            raise ValueError(
+                f"Base URL is not a valid base URL: {base_url}. "
+                f"Try setting environment variable(s): {global_configs.get_env_var_help('U1_IMAGE_GEN_BASE_URL')}"
+            )
         return base_url
 
     @override
     def get_api_url(self, model: str | None = None) -> str:
         model = model or self.model
-        base_url = self.base_url.rstrip("/")
-        base_path = f"{base_url}/v1beta/models/{model}"
+        base_path = f"{self.base_url}/v1beta/models/{model}"
         return f"{base_path}:generateContent"
 
     @override

--- a/skills/u1-image-base/u1_image_base/generation/nano_banana.py
+++ b/skills/u1-image-base/u1_image_base/generation/nano_banana.py
@@ -136,11 +136,11 @@ class NanoBananaText2ImageClient(T2IBaseClient):
                     if env_names:
                         if len(env_names) == 1:
                             details += (
-                                f"Is the environment variable `{env_names[0]}` set correctly?"
+                                f"\nIs the environment variable `{env_names[0]}` set correctly?"
                             )
                         else:
                             env_names_str = ", ".join([f"`{n}`" for n in env_names])
-                            details += f"Is any of the following environment variable(s) set correctly: {env_names_str}?"
+                            details += f"\nIs any of the following environment variable(s) set correctly: {env_names_str}?"
             return {
                 "status": "failed",
                 "error": f"HTTP {exc.code}: {exc.message}",
@@ -206,7 +206,7 @@ class NanoBananaText2ImageClient(T2IBaseClient):
     @override
     def get_api_url(self, model: str | None = None) -> str:
         model = model or self.model
-        base_path = f"{self.base_url}/v1beta/models/{model}"
+        base_path = f"{self.base_url.rstrip('/')}/v1beta/models/{model}"
         return f"{base_path}:generateContent"
 
     @override

--- a/skills/u1-image-base/u1_image_base/generation/nano_banana.py
+++ b/skills/u1-image-base/u1_image_base/generation/nano_banana.py
@@ -9,10 +9,14 @@ import httpx
 from typing_extensions import override
 
 from u1_image_base.configs import global_configs, is_valid_base_url
-from u1_image_base.utils.error_utils import U1HttpErrorBase, U1HttpNotFoundError
+from u1_image_base.utils.error_utils import U1HttpErrorBase
 
 from .core import ensure_output_path
-from .core.client_base import DEFAULT_HTTP_REQUEST_TIMEOUT, DEFAULT_MAX_CONNECTIONS, T2IBaseClient
+from .core.client_base import (
+    DEFAULT_HTTP_REQUEST_TIMEOUT,
+    DEFAULT_MAX_CONNECTIONS,
+    T2IBaseClient,
+)
 
 DEFAULT_MODEL_SIZE: Literal["1K", "2K", "4K"] = "2K"
 DEFAULT_ASPECT_RATIO = "16:9"

--- a/skills/u1-image-base/u1_image_base/generation/nano_banana.py
+++ b/skills/u1-image-base/u1_image_base/generation/nano_banana.py
@@ -27,6 +27,9 @@ OUTPUT_DIR = Path("/tmp/openclaw-u1-image")
 class NanoBananaText2ImageClient(T2IBaseClient):
     """Async client for U1 text-to-image-no-enhance API."""
 
+    # requires `{model}` placeholder for format string
+    DEFAULT_API_PATH = "/v1beta/models/{model}:generateContent"
+
     def __init__(
         self,
         api_key: str,
@@ -210,8 +213,9 @@ class NanoBananaText2ImageClient(T2IBaseClient):
     @override
     def get_api_url(self, model: str | None = None) -> str:
         model = model or self.model
-        base_path = f"{self.base_url.rstrip('/')}/v1beta/models/{model}"
-        return f"{base_path}:generateContent"
+        path = self.DEFAULT_API_PATH.format(model=model).lstrip("/")
+        api_url = f"{self.base_url.rstrip('/')}/{path}"
+        return api_url
 
     @override
     def build_payload(

--- a/skills/u1-image-base/u1_image_base/generation/u1_text_to_image.py
+++ b/skills/u1-image-base/u1_image_base/generation/u1_text_to_image.py
@@ -24,7 +24,11 @@ from u1_image_base.u1_api.paths import (
 )
 
 from .core import download_image, ensure_output_path, extract_task_image
-from .core.client_base import DEFAULT_HTTP_REQUEST_TIMEOUT, DEFAULT_MAX_CONNECTIONS, T2IBaseClient
+from .core.client_base import (
+    DEFAULT_HTTP_REQUEST_TIMEOUT,
+    DEFAULT_MAX_CONNECTIONS,
+    T2IBaseClient,
+)
 
 DEFAULT_MODEL_SIZE = "2k"
 DEFAULT_ASPECT_RATIO = "16:9"

--- a/skills/u1-image-base/u1_image_base/generation/u1_text_to_image.py
+++ b/skills/u1-image-base/u1_image_base/generation/u1_text_to_image.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import httpx
 from typing_extensions import Any, Literal, override
 
-from u1_image_base.configs import global_configs
+from u1_image_base.configs import global_configs, is_valid_base_url
 from u1_image_base.u1_api.paths import (
     text_to_image_create_url,
     text_to_image_status_url,
@@ -217,6 +217,11 @@ class U1Text2ImageClient(T2IBaseClient):
                 "Base URL is missing: {}".format(
                     global_configs.get_env_var_help("U1_IMAGE_GEN_BASE_URL")
                 )
+            )
+        if not is_valid_base_url(base_url):
+            raise ValueError(
+                f"Base URL is not a valid base URL: {base_url}. "
+                f"Try setting environment variable(s): {global_configs.get_env_var_help('U1_IMAGE_GEN_BASE_URL')}"
             )
         return base_url
 

--- a/skills/u1-image-base/u1_image_base/llm/anthropic_adapter.py
+++ b/skills/u1-image-base/u1_image_base/llm/anthropic_adapter.py
@@ -23,6 +23,8 @@ from typing import Any
 
 import httpx
 
+from ..utils.error_utils import U1HttpResponseParseError
+from ..utils.httpx_client import httpx_response_raise_for_status_code
 from .llm_adapter import LlmAdapter
 
 logger = logging.getLogger(__name__)
@@ -175,8 +177,15 @@ class AnthropicMessagesAdapter(LlmAdapter):
             "x-api-key": self._api_key,
         }
         resp = await self._get_client().post(self._url, json=payload, headers=headers)
-        resp.raise_for_status()
-        return self._parse_response(resp.json())
+        httpx_response_raise_for_status_code(resp)
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise U1HttpResponseParseError(
+                detail=f"Failed to parse HTTP response. {resp.request.url}. Response content: {resp.content}",
+                code=resp.status_code,
+            ) from exc
+        return self._parse_response(data)
 
     async def aclose(self) -> None:
         """Close the internal async HTTP client if we own it.

--- a/skills/u1-image-base/u1_image_base/llm/chat_completions_adapter.py
+++ b/skills/u1-image-base/u1_image_base/llm/chat_completions_adapter.py
@@ -24,6 +24,8 @@ from typing import Any
 
 import httpx
 
+from ..utils.error_utils import U1HttpResponseParseError
+from ..utils.httpx_client import httpx_response_raise_for_status_code
 from .llm_adapter import LlmAdapter
 
 logger = logging.getLogger(__name__)
@@ -179,8 +181,15 @@ class ChatCompletionsLlmAdapter(LlmAdapter):
             "Content-Type": "application/json",
         }
         resp = await self._get_client().post(self._url, json=payload, headers=headers)
-        resp.raise_for_status()
-        return self._parse_response(resp.json())
+        httpx_response_raise_for_status_code(resp)
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise U1HttpResponseParseError(
+                detail=f"Failed to parse HTTP response. {resp.request.url}. Response content: {resp.content}",
+                code=resp.status_code,
+            ) from exc
+        return self._parse_response(data)
 
     async def aclose(self) -> None:
         """Close the internal async HTTP client if we own it.

--- a/skills/u1-image-base/u1_image_base/u1_api/paths.py
+++ b/skills/u1-image-base/u1_image_base/u1_api/paths.py
@@ -29,18 +29,10 @@ def join_base(base_url: str, path: str) -> str:
 
     Returns:
         str:
-            The joined URL with the base stripped of trailing slashes and
-            the path prepended with a leading slash if missing.
+            The joined URL, with the path of base_url ignored.
     """
-    try:
-        parsed = urlparse(base_url)
-    except ValueError as e:
-        raise ValueError(f"Invalid base URL: {base_url}") from e
-    try:
-        url = urljoin(parsed.geturl(), path)
-    except ValueError as e:
-        raise ValueError(f"Invalid URL path: {path}") from e
-    return url
+    parsed = urlparse(base_url)
+    return urljoin(parsed.geturl(), path)
 
 
 def text_to_image_create_url(base_url: str) -> str:

--- a/skills/u1-image-base/u1_image_base/u1_api/paths.py
+++ b/skills/u1-image-base/u1_image_base/u1_api/paths.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from urllib.parse import quote
+from urllib.parse import quote, urljoin, urlparse
 
 GENERATION_TEXT_TO_IMAGE = "/v1/generation/text-to-image"
 IMAGE_EDIT = "/v1/generation/image-edit"
@@ -12,6 +12,14 @@ PROMPTS_EXPAND = "/v1/generation/prompts/expand"
 
 def join_base(base_url: str, path: str) -> str:
     """Join a base URL with a path segment.
+    The path of base_url is ignored.
+
+    Example:
+        join_base("https://api.example.com", "/v1/generation/text-to-image")
+        -> "https://api.example.com/v1/generation/text-to-image"
+
+        join_base("https://api.example.com/v1", "/v2/generation/text-to-image")
+        -> "https://api.example.com/v2/generation/text-to-image"  # `"/v1"` is ignored
 
     Args:
         base_url (str):
@@ -24,10 +32,15 @@ def join_base(base_url: str, path: str) -> str:
             The joined URL with the base stripped of trailing slashes and
             the path prepended with a leading slash if missing.
     """
-    base = base_url.rstrip("/")
-    if not path.startswith("/"):
-        path = f"/{path}"
-    return f"{base}{path}"
+    try:
+        parsed = urlparse(base_url)
+    except ValueError as e:
+        raise ValueError(f"Invalid base URL: {base_url}") from e
+    try:
+        url = urljoin(parsed.geturl(), path)
+    except ValueError as e:
+        raise ValueError(f"Invalid URL path: {path}") from e
+    return url
 
 
 def text_to_image_create_url(base_url: str) -> str:

--- a/skills/u1-image-base/u1_image_base/u1_api/paths.py
+++ b/skills/u1-image-base/u1_image_base/u1_api/paths.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from urllib.parse import quote, urljoin, urlparse
+from urllib.parse import quote
 
 GENERATION_TEXT_TO_IMAGE = "/v1/generation/text-to-image"
 IMAGE_EDIT = "/v1/generation/image-edit"
@@ -12,14 +12,6 @@ PROMPTS_EXPAND = "/v1/generation/prompts/expand"
 
 def join_base(base_url: str, path: str) -> str:
     """Join a base URL with a path segment.
-    The path of base_url is ignored.
-
-    Example:
-        join_base("https://api.example.com", "/v1/generation/text-to-image")
-        -> "https://api.example.com/v1/generation/text-to-image"
-
-        join_base("https://api.example.com/v1", "/v2/generation/text-to-image")
-        -> "https://api.example.com/v2/generation/text-to-image"  # `"/v1"` is ignored
 
     Args:
         base_url (str):
@@ -29,10 +21,12 @@ def join_base(base_url: str, path: str) -> str:
 
     Returns:
         str:
-            The joined URL, with the path of base_url ignored.
+            The joined URL with the base stripped of trailing slashes and
+            the path prepended with a leading slash if missing.
     """
-    parsed = urlparse(base_url)
-    return urljoin(parsed.geturl(), path)
+    base = base_url.rstrip("/")
+    path = path.lstrip("/")
+    return f"{base}/{path}"
 
 
 def text_to_image_create_url(base_url: str) -> str:
@@ -124,7 +118,9 @@ def generation_file_download_url(base_url: str, image_ref: str) -> str:
             key URL-encoded.
     """
     image_key = image_ref.lstrip("/")
-    return f"{join_base(base_url, GENERATION_FILES_PREFIX)}/{quote(image_key, safe='/')}"
+    return (
+        f"{join_base(base_url, GENERATION_FILES_PREFIX)}/{quote(image_key, safe='/')}"
+    )
 
 
 def generation_file_upload_url(base_url: str) -> str:

--- a/skills/u1-image-base/u1_image_base/u1_api/paths.py
+++ b/skills/u1-image-base/u1_image_base/u1_api/paths.py
@@ -118,9 +118,7 @@ def generation_file_download_url(base_url: str, image_ref: str) -> str:
             key URL-encoded.
     """
     image_key = image_ref.lstrip("/")
-    return (
-        f"{join_base(base_url, GENERATION_FILES_PREFIX)}/{quote(image_key, safe='/')}"
-    )
+    return f"{join_base(base_url, GENERATION_FILES_PREFIX)}/{quote(image_key, safe='/')}"
 
 
 def generation_file_upload_url(base_url: str) -> str:

--- a/skills/u1-image-base/u1_image_base/utils/error_utils.py
+++ b/skills/u1-image-base/u1_image_base/utils/error_utils.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 
 
 class U1BaseError(Exception):
@@ -6,9 +6,9 @@ class U1BaseError(Exception):
 
     def __init__(
         self,
-        message: str | None = None,
-        detail: str | None = None,
-        code: int | None = None,
+        message: Union[str, None] = None,
+        detail: Union[str, None] = None,
+        code: Union[int, None] = None,
         **kwargs: Any,
     ) -> None:
         if message is None:
@@ -33,6 +33,10 @@ class U1HttpErrorBase(U1BaseError):
 
 class U1HttpAuthError(U1HttpErrorBase):
     MESSAGE = "Authentication or Authorization Failed"
+
+
+class U1HttpNotFoundError(U1HttpErrorBase):
+    MESSAGE = "Resource Not Found"
 
 
 class U1HttpTooManyRequestsError(U1HttpErrorBase):

--- a/skills/u1-image-base/u1_image_base/utils/error_utils.py
+++ b/skills/u1-image-base/u1_image_base/utils/error_utils.py
@@ -1,4 +1,6 @@
-from typing import Any, Union
+from __future__ import annotations
+
+from typing import Any
 
 
 class U1BaseError(Exception):
@@ -6,9 +8,9 @@ class U1BaseError(Exception):
 
     def __init__(
         self,
-        message: Union[str, None] = None,
-        detail: Union[str, None] = None,
-        code: Union[int, None] = None,
+        message: str | None = None,
+        detail: str | None = None,
+        code: int | None = None,
         **kwargs: Any,
     ) -> None:
         if message is None:

--- a/skills/u1-image-base/u1_image_base/utils/httpx_client.py
+++ b/skills/u1-image-base/u1_image_base/utils/httpx_client.py
@@ -14,6 +14,7 @@ import httpx
 from .error_utils import (
     U1HttpAuthError,
     U1HttpBadRequestError,
+    U1HttpNotFoundError,
     U1HttpServerError,
     U1HttpTooManyRequestsError,
 )
@@ -149,25 +150,31 @@ def httpx_response_raise_for_status_code(response: httpx.Response) -> None:
         response_content = json.loads(response_content)
     with contextlib.suppress(Exception):
         request_method = response.request.method
+        request_method = request_method.upper()
         request_url = str(response.request.url)
 
+    if response.status_code == 404:
+        raise U1HttpNotFoundError(
+            detail=f"{request_method} {request_url!r} not found. Please check the URL.",
+            code=response.status_code,
+        )
     if response.status_code in (401, 403):
         raise U1HttpAuthError(
-            detail=f"Authentication or authorization failed. {request_url} {request_method}. Response content: {response_content}",
+            detail=f"Authentication or authorization failed. {request_method} {request_url!r}. Response content: {response_content}",
             code=response.status_code,
         )
     elif response.status_code in (429, 503):
         raise U1HttpTooManyRequestsError(
-            detail=f"Service temporarily unavailable. {request_url} {request_method}. Response content: {response_content}",
+            detail=f"Service temporarily unavailable. {request_method} {request_url!r}. Response content: {response_content}",
             code=response.status_code,
         )
     elif 500 <= response.status_code <= 599:
         raise U1HttpServerError(
-            detail=f"Request failed. {request_url} {request_method}. Response content: {response_content}",
+            detail=f"Request failed. {request_method} {request_url!r}. Response content: {response_content}",
             code=response.status_code,
         )
     elif 400 <= response.status_code <= 499:
         raise U1HttpBadRequestError(
-            detail=f"Bad request. {request_url} {request_method}. Response content: {response_content}",
+            detail=f"Bad request. {request_method} {request_url!r}. Response content: {response_content}",
             code=response.status_code,
         )

--- a/skills/u1-image-base/u1_image_base/utils/httpx_client.py
+++ b/skills/u1-image-base/u1_image_base/utils/httpx_client.py
@@ -165,7 +165,7 @@ def httpx_response_raise_for_status_code(response: httpx.Response) -> None:
         )
     elif response.status_code in (429, 503):
         raise U1HttpTooManyRequestsError(
-            detail=f"Service temporarily unavailable. {request_method} {request_url!r}. Response content: {response_content}",
+            detail=f"Service temporarily unavailable. Please try again later. {request_method} {request_url!r}. Response content: {response_content}",
             code=response.status_code,
         )
     elif 500 <= response.status_code <= 599:

--- a/skills/u1-image-base/u1_image_base/vlm/anthropic_adapter.py
+++ b/skills/u1-image-base/u1_image_base/vlm/anthropic_adapter.py
@@ -110,14 +110,16 @@ class AnthropicVlmAdapter(VlmAdapter):
         blocks: list[dict[str, Any]] = [{"type": "text", "text": user_prompt}]
         for img in images:
             mime, b64 = image_to_base64(img)
-            blocks.append({
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "media_type": mime,
-                    "data": b64,
-                },
-            })
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime,
+                        "data": b64,
+                    },
+                }
+            )
         return blocks
 
     def _build_payload(
@@ -141,10 +143,12 @@ class AnthropicVlmAdapter(VlmAdapter):
         messages: list[dict[str, Any]] = []
         if system_prompt:
             messages.append({"role": "user", "content": system_prompt})
-        messages.append({
-            "role": "user",
-            "content": self._build_content_blocks(user_prompt, images),
-        })
+        messages.append(
+            {
+                "role": "user",
+                "content": self._build_content_blocks(user_prompt, images),
+            }
+        )
 
         payload: dict[str, Any] = {
             "model": model or self._default_model,

--- a/skills/u1-image-base/u1_image_base/vlm/anthropic_adapter.py
+++ b/skills/u1-image-base/u1_image_base/vlm/anthropic_adapter.py
@@ -24,6 +24,8 @@ from typing import Any
 
 import httpx
 
+from ..utils.error_utils import U1HttpResponseParseError
+from ..utils.httpx_client import httpx_response_raise_for_status_code
 from .utils import image_to_base64
 from .vlm_adapter import VlmAdapter
 
@@ -108,16 +110,14 @@ class AnthropicVlmAdapter(VlmAdapter):
         blocks: list[dict[str, Any]] = [{"type": "text", "text": user_prompt}]
         for img in images:
             mime, b64 = image_to_base64(img)
-            blocks.append(
-                {
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": mime,
-                        "data": b64,
-                    },
-                }
-            )
+            blocks.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": mime,
+                    "data": b64,
+                },
+            })
         return blocks
 
     def _build_payload(
@@ -141,12 +141,10 @@ class AnthropicVlmAdapter(VlmAdapter):
         messages: list[dict[str, Any]] = []
         if system_prompt:
             messages.append({"role": "user", "content": system_prompt})
-        messages.append(
-            {
-                "role": "user",
-                "content": self._build_content_blocks(user_prompt, images),
-            }
-        )
+        messages.append({
+            "role": "user",
+            "content": self._build_content_blocks(user_prompt, images),
+        })
 
         payload: dict[str, Any] = {
             "model": model or self._default_model,
@@ -212,8 +210,15 @@ class AnthropicVlmAdapter(VlmAdapter):
             "x-api-key": self._api_key,
         }
         resp = await self._get_client().post(self._url, json=payload, headers=headers)
-        resp.raise_for_status()
-        return self._parse_response(resp.json())
+        httpx_response_raise_for_status_code(resp)
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise U1HttpResponseParseError(
+                detail=f"Failed to parse HTTP response. {resp.request.url}. Response content: {resp.content}",
+                code=resp.status_code,
+            ) from exc
+        return self._parse_response(data)
 
     async def aclose(self) -> None:
         """Close the internal async HTTP client if we own it.

--- a/skills/u1-image-base/u1_image_base/vlm/chat_completions_adapter.py
+++ b/skills/u1-image-base/u1_image_base/vlm/chat_completions_adapter.py
@@ -25,6 +25,8 @@ from typing import Any
 
 import httpx
 
+from ..utils.error_utils import U1HttpResponseParseError
+from ..utils.httpx_client import httpx_response_raise_for_status_code
 from .utils import image_to_data_url
 from .vlm_adapter import VlmAdapter
 
@@ -209,8 +211,15 @@ class ChatCompletionsVlmAdapter(VlmAdapter):
             "Content-Type": "application/json",
         }
         resp = await self._get_client().post(self._url, json=payload, headers=headers)
-        resp.raise_for_status()
-        return self._parse_response(resp.json())
+        httpx_response_raise_for_status_code(resp)
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise U1HttpResponseParseError(
+                detail=f"Failed to parse HTTP response. {resp.request.url}. Response content: {resp.content}",
+                code=resp.status_code,
+            ) from exc
+        return self._parse_response(data)
 
     async def aclose(self) -> None:
         """Close the internal async HTTP client if we own it.


### PR DESCRIPTION
Enhance URL validation, providing more informative message for users/agents.

## Summary

- Added `U1HttpNotFoundError` (404) and URL validation (`is_valid_base_url`) for base URLs in configs and image generation clients; 404/401 errors now surface actionable env-var hints to the user
- Replaced `raise_for_status()` with a custom `httpx_response_raise_for_status_code()` in all LLM/VLM adapters; added `U1HttpResponseParseError` for JSON parse failures with full response context
- Refactored `join_base` in `paths.py` to use `urljoin` (path of base_url is now intentionally ignored); fixed trailing-slash regression in `NanoBananaText2ImageClient.get_api_url` and missing newline in error message concatenation