### PR TITLE
docs: add per-category usage guides under docs/ and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,19 @@ skills/
 
 ### 🎨 图像与可视化
 
+📖 详细使用指南：[`docs/u1-image-generate.md`](docs/u1-image-generate.md)（环境要求、Quick Start、API 配置与调用样例）。
+
 
 | 名称                                                 | 标签            | 描述                                                                                              |
 | -------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------- |
 | [`u1-doctor`](skills/u1-doctor/SKILL.md)           | 环境诊断          | 检查 SenseNova-Skills 环境，验证 `u1-image-base` 安装、Python 依赖与必填环境变量；交互式补齐缺失项并写入 `.env`。               |
-| [`u1-image-base`](skills/u1-image-base/SKILL.md)   | 图像基础层（Tier 0） | 提供文生图（`u1-image-generate`）和文本优化（`u1-text-optimize`）两个底层工具，统一通过 `openclaw_runner.py` 调用，供上层技能复用。 |
+| [`u1-image-base`](skills/u1-image-base/SKILL.md)   | 图像基础层（Tier 0） | 提供文生图（`u1-image-generate`）、图像识别（`u1-image-recognize`）与文本优化（`u1-text-optimize`）三个底层工具，统一通过 `openclaw_runner.py` 调用，供上层技能复用。 |
 | [`u1-infographic`](skills/u1-infographic/SKILL.md) | 信息图生成（Tier 1） | 自动评估提示词、从 87 种布局 / 66 种风格中选型，多轮生成 + VLM 评审 + 质量排序，输出专业级信息图。                                     |
 
 
 ### 📊 演示文稿（PPT）
+
+📖 详细使用指南：[`docs/ppt-generate.md`](docs/ppt-generate.md)（环境要求、Quick Start、API 配置与调用样例）。
 
 
 | 名称                                             | 标签         | 描述                                                                                                                         |
@@ -61,6 +65,8 @@ skills/
 
 ### 📈 数据分析（DA）
 
+📖 详细使用指南：[`docs/data-analysis.md`](docs/data-analysis.md)（环境要求、Quick Start、API 配置与调用样例）。
+
 
 | 名称                                                                 | 标签         | 描述                                                                               |
 | ------------------------------------------------------------------ | ---------- | -------------------------------------------------------------------------------- |
@@ -70,6 +76,8 @@ skills/
 
 
 ### 🔬 深度研究
+
+📖 详细使用指南：[`docs/deep-research.md`](docs/deep-research.md)（环境要求、`web_search` 硬检查、Quick Start 与各阶段调用）。
 
 
 | 名称                                                                   | 标签        | 描述                                                                                      |
@@ -83,6 +91,8 @@ skills/
 
 
 ### 🔍 搜索
+
+📖 搜索技能与深度研究合并在同一份文档：[`docs/deep-research.md`](docs/deep-research.md)（含各平台 API key、调用方式与统一 JSON 输出）。
 
 
 | 名称                                                     | 标签     | 描述                                                                                          |

--- a/README_en.md
+++ b/README_en.md
@@ -40,15 +40,19 @@ skills/
 
 ### 🎨 Image & Visualization
 
+📖 Full guide: [`docs/u1-image-generate_en.md`](docs/u1-image-generate_en.md) (prerequisites, Quick Start, API config, and invocation samples).
+
 
 | Name                                               | Label                          | Description                                                                                                                                                       |
 | -------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`u1-doctor`](skills/u1-doctor/SKILL.md)           | Environment Doctor             | Validates the SenseNova-Skills environment — checks `u1-image-base` install, Python deps, and required env vars; interactively fills missing values into `.env`. |
-| [`u1-image-base`](skills/u1-image-base/SKILL.md)   | Image Base Layer (Tier 0)      | Low-level tools — text-to-image (`u1-image-generate`) and text optimization (`u1-text-optimize`) — exposed through a unified `openclaw_runner.py`, designed to be called by upper-layer skills. |
+| [`u1-image-base`](skills/u1-image-base/SKILL.md)   | Image Base Layer (Tier 0)      | Low-level tools — text-to-image (`u1-image-generate`), image recognition (`u1-image-recognize`), and text optimization (`u1-text-optimize`) — exposed through a unified `openclaw_runner.py`, designed to be called by upper-layer skills. |
 | [`u1-infographic`](skills/u1-infographic/SKILL.md) | Infographic Generation (Tier 1) | Auto prompt-quality scoring, layout/style selection (87 layouts / 66 styles), multi-round generation with VLM review and quality ranking, producing publication-ready infographics. |
 
 
 ### 📊 Presentations (PPT)
+
+📖 Full guide: [`docs/ppt-generate_en.md`](docs/ppt-generate_en.md) (prerequisites, Quick Start, API config, and invocation samples).
 
 
 | Name                                           | Label                  | Description                                                                                                                                                                                                              |
@@ -61,6 +65,8 @@ skills/
 
 ### 📈 Data Analysis (DA)
 
+📖 Full guide: [`docs/data-analysis_en.md`](docs/data-analysis_en.md) (prerequisites, Quick Start, API config, and invocation samples).
+
 
 | Name                                                               | Label                                | Description                                                                                                                                                            |
 | ------------------------------------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -70,6 +76,8 @@ skills/
 
 
 ### 🔬 Deep Research
+
+📖 Full guide: [`docs/deep-research_en.md`](docs/deep-research_en.md) (prerequisites, `web_search` precheck, Quick Start, and per-stage invocation).
 
 
 | Name                                                                 | Label                          | Description                                                                                                                                                       |
@@ -83,6 +91,8 @@ skills/
 
 
 ### 🔍 Search
+
+📖 Search skills are documented together with deep research: [`docs/deep-research_en.md`](docs/deep-research_en.md) (includes per-platform API keys, invocation, and unified JSON output).
 
 
 | Name                                                   | Label                  | Description                                                                                                                                |

--- a/docs/data-analysis.md
+++ b/docs/data-analysis.md
@@ -1,0 +1,67 @@
+# 数据分析（DA）相关技能
+
+简体中文 | [English](data-analysis_en.md)
+
+本文档汇总数据分析（Data Analysis）相关技能（`da-excel-workflow`、`da-image-caption`、`da-large-file-analysis`），覆盖 Excel 多表读取与清洗、大文件高性能分析、图像数据提取与可视化。
+
+## 环境要求
+
+- **Python** 3.9 或更高版本（推荐 3.10+）。
+- 常用数据栈：`pandas`、`openpyxl`（含 read_only 模式）、`pyarrow`、`matplotlib`、`numpy`。
+- `da-image-caption` 需要 VLM API 凭据。
+
+## 技能介绍
+
+| 名称 | 角色 | 说明 |
+|------|------|------|
+| [`da-excel-workflow`](../skills/da-excel-workflow/SKILL.md) | Excel 分析编排 | 多表读取、大文件检测（≥10k 行触发 Parquet 优化、≥100k 行交由 `da-large-file-analysis`）、清洗、条件过滤、跨表聚合、Excel/CSV 导出的全流程编排。 |
+| [`da-image-caption`](../skills/da-image-caption/SKILL.md) | 图像理解与数据提取 | 表格 OCR / 图表解读 / 截图描述 / UI 描述；可解析为 DataFrame、复绘可视化、导出 Excel/CSV。 |
+| [`da-large-file-analysis`](../skills/da-large-file-analysis/SKILL.md) | 大文件高性能分析 | 流式读取（`openpyxl read_only` + `iter_rows`）、Parquet 转换、内存优化（类型降阶）、向量化操作、分块写入。 |
+
+`da-excel-workflow` 是常用入口，根据文件规模自动选用读写策略并按需路由到 `da-large-file-analysis`。
+
+## Quick Start
+
+通过 [OpenClaw](https://openclaw.ai/) 使用这些技能。技能注册步骤参考 [`u1-image-generate.md`](u1-image-generate.md#1-注册技能)。
+
+### 1. Python 依赖
+
+DA 技能未提供独立的 `requirements.txt`，依赖通常已包含在执行环境的基础镜像中。如需自行准备环境：
+
+```bash
+pip install pandas openpyxl pyarrow matplotlib numpy
+```
+
+`da-image-caption` 还需要 HTTP 客户端（`requests` 或 `httpx`）。
+
+### 2. API Key 与环境变量
+
+`da-image-caption` 通过视觉模型解析图像，需要在 `~/.openclaw/.env`（或 `~/.hermes/.env`）中设置：
+
+```ini
+VISION_API_KEY="your-vision-api-key"
+VISION_API_BASE="https://your-vlm-endpoint"
+```
+
+`da-excel-workflow` 与 `da-large-file-analysis` 不直接调用模型，无需 API key。
+
+### 3. 在智能体中调用
+
+把数据文件交给智能体并描述需求即可：
+
+> "分析这个 Excel：按部门汇总销售额，导出 CSV"
+
+或显式按名调用：
+
+> /skill da-excel-workflow
+
+图像类任务：
+
+> "看一下这张图表，把里面的数据提成 Excel"
+> /skill da-image-caption
+
+## 输出物
+
+- 分析结果通常落盘为 `*.xlsx` / `*.csv`（或可视化图片）
+- 大文件场景会生成 Parquet 中间文件以加速后续步骤
+- 图像解析可输出结构化 JSON 或 Markdown 表格

--- a/docs/data-analysis_en.md
+++ b/docs/data-analysis_en.md
@@ -1,0 +1,67 @@
+# Data Analysis (DA) Skills
+
+English | [简体中文](data-analysis.md)
+
+This document collects the data-analysis skills (`da-excel-workflow`, `da-image-caption`, `da-large-file-analysis`) covering multi-sheet Excel ingestion and cleaning, high-performance large-file analysis, and image-based data extraction and visualization.
+
+## Prerequisites
+
+- **Python** 3.9 or later (3.10+ recommended).
+- Standard data stack: `pandas`, `openpyxl` (with read_only mode), `pyarrow`, `matplotlib`, `numpy`.
+- `da-image-caption` requires VLM API credentials.
+
+## Skills
+
+| Name | Role | Description |
+|------|------|-------------|
+| [`da-excel-workflow`](../skills/da-excel-workflow/SKILL.md) | Excel analysis orchestrator | Multi-sheet read, large-file detection (≥10k rows triggers Parquet optimization, ≥100k routes to `da-large-file-analysis`), cleaning, conditional filtering, cross-sheet aggregation, and Excel/CSV export. |
+| [`da-image-caption`](../skills/da-image-caption/SKILL.md) | Image understanding & data extraction | Table OCR / chart interpretation / screenshot description / UI description; can return DataFrame, re-render visualizations, and export Excel/CSV. |
+| [`da-large-file-analysis`](../skills/da-large-file-analysis/SKILL.md) | High-performance large-file analysis | Streaming read (`openpyxl read_only` + `iter_rows`), Parquet conversion, memory optimization (dtype downcasting), vectorized operations, chunked writes. |
+
+`da-excel-workflow` is the typical entry point and auto-selects read/write strategy by file size, routing to `da-large-file-analysis` when needed.
+
+## Quick Start
+
+Use these skills from [OpenClaw](https://openclaw.ai/). For skill registration steps, see [`u1-image-generate_en.md`](u1-image-generate_en.md#1-register-skills).
+
+### 1. Python dependencies
+
+DA skills do not ship a per-skill `requirements.txt`; deps are typically present in the base execution image. If preparing a fresh environment:
+
+```bash
+pip install pandas openpyxl pyarrow matplotlib numpy
+```
+
+`da-image-caption` additionally needs an HTTP client (`requests` or `httpx`).
+
+### 2. API keys and environment variables
+
+`da-image-caption` calls a vision model for image parsing. Set in `~/.openclaw/.env` (or `~/.hermes/.env`):
+
+```ini
+VISION_API_KEY="your-vision-api-key"
+VISION_API_BASE="https://your-vlm-endpoint"
+```
+
+`da-excel-workflow` and `da-large-file-analysis` do not call models directly and need no API key.
+
+### 3. Invoke in Agent
+
+Provide the data file and describe the task:
+
+> "Analyze this Excel: aggregate sales by department, export CSV"
+
+Or call by name:
+
+> /skill da-excel-workflow
+
+Image tasks:
+
+> "Read this chart and extract the data into Excel"
+> /skill da-image-caption
+
+## Outputs
+
+- Analysis results are written to `*.xlsx` / `*.csv` (or visualization images)
+- Large-file flows produce intermediate Parquet files to accelerate subsequent steps
+- Image parsing returns structured JSON or Markdown tables

--- a/docs/deep-research.md
+++ b/docs/deep-research.md
@@ -1,0 +1,143 @@
+# 深度研究与搜索相关技能
+
+简体中文 | [English](deep-research_en.md)
+
+本文档汇总深度研究（`deep-research`、`research-planning`、`dimension-research`、`research-synthesis`、`research-report`、`report-format-discovery`）与搜索（`search-academic`、`search-code`、`search-social-cn`、`search-social-en`）相关技能。
+
+深度研究技能负责规划、综合与成稿；搜索技能由 `dimension-research` 在分维度取证阶段调用，覆盖学术论文、开发者资源、中英文社交平台。两类技能编排成端到端流水线。
+
+## 环境要求
+
+- **Python** 3.9 或更高版本（推荐 3.10+）。
+- **OpenClaw 必须已配置可用的 `web_search`**（深度研究编排器在启动时硬检查）。
+- 视维度需要，可选 / 必填若干平台的 API key（详见 [API Key](#2-api-key)）。
+
+## 深度研究技能
+
+| 名称 | 角色 | 说明 |
+|------|------|------|
+| [`deep-research`](../skills/deep-research/SKILL.md) | **深度研究入口** | 全流程编排器：`request.md → plan.json → sub_reports/*.md → synthesis.md → report.md`，产物落盘到 `report_dir`，支持断点续跑。 |
+| [`research-planning`](../skills/research-planning/SKILL.md) | 研究规划 | 基于 `request.md` 一次性产出 `plan.json`，覆盖定界、报告形态、维度拆解（3–8 维度）、关键问题、搜索策略、依赖与完成标准。 |
+| [`dimension-research`](../skills/dimension-research/SKILL.md) | 单维度取证 | 按 `plan.json` 中维度的 `search_strategy` 调用[搜索技能](#搜索技能)完成多轮取证、交叉验证，产出 `sub_reports/{dimension_id}.md`。 |
+| [`research-synthesis`](../skills/research-synthesis/SKILL.md) | 综合判断 | 把多个 `sub_reports` 综合为 `synthesis.md`，明确主线判断、证据强弱、跨维度共识、关键冲突与不确定性。 |
+| [`research-report`](../skills/research-report/SKILL.md) | 终稿写作 / 改写 | 把判断层落成最终 `report.md`；也可对已有报告做重写、润色、重组结构、补充表格等定向编辑。 |
+| [`report-format-discovery`](../skills/report-format-discovery/SKILL.md) | 报告形态发现 | 研究"这类报告应该长什么样"，给出章节结构、必备元素与风格约束；可独立使用，也可为 `deep-research` 的 `report_shape` 提供依据。 |
+
+## 搜索技能
+
+| 名称 | 角色 | 说明 |
+|------|------|------|
+| [`search-academic`](../skills/search-academic/SKILL.md) | 学术搜索 | ArXiv（含 HTML 全文按章节读）/ Semantic Scholar（含引用数与正反向引用链）/ PubMed（含 PMC 开放获取全文）/ Wikipedia 多语言聚合。 |
+| [`search-code`](../skills/search-code/SKILL.md) | 开发者搜索 | GitHub（仓库 / 代码 / Issue）/ Stack Overflow（按标签 / 票数）/ HuggingFace（模型 / 数据集 / Space）/ Hacker News 四平台聚合。 |
+| [`search-social-cn`](../skills/search-social-cn/SKILL.md) | 中文社交搜索 | B 站 / 知乎 / 抖音 三个中文社交平台搜索；知乎、抖音必须配 cookie，B 站 cookie 可选。 |
+| [`search-social-en`](../skills/search-social-en/SKILL.md) | 英文社交搜索 | Reddit（按 subreddit / 排序 / 时间）/ Twitter (X)（经 TikHub）/ YouTube（API key）。 |
+
+`_search-common` 是各搜索技能共用的工具模块（`search_utils.py`），不直接面向用户。
+
+## Quick Start
+
+通过 [OpenClaw](https://openclaw.ai/) 使用这些技能。技能注册步骤参考 [`u1-image-generate.md`](u1-image-generate.md#1-注册技能)。
+
+### 1. 启动前硬检查：`web_search`
+
+`deep-research` 在创建 `report_dir`、写 `request.md` 或进入任何研究阶段之前，**必须确认当前 OpenClaw `web_search` 可用**。未确认时不要开始研究，也不要用记忆或既有知识替代联网取证。
+
+- 静态检查：确认 `tools.web.search.provider` 与 `plugins.entries.<plugin>.config.webSearch.*` 已配置
+- 不确定时发起一次极小的 `web_search` 探测；返回结果即可继续；返回缺 key、provider 未就绪、服务不可达或 search disabled 则停止
+
+### 2. API Key
+
+按需在 `~/.openclaw/.env`（或 `~/.hermes/.env`）中配置：
+
+| 平台 | 必填 / 可选 | 环境变量 | 说明 |
+|------|------|----------|------|
+| GitHub 仓库/Issue 搜索 | 可选（提高限额） | `GITHUB_TOKEN` | 公开搜索可匿名 |
+| GitHub 代码搜索 | **必填** | `GITHUB_TOKEN` | `--type code` 必须提供 |
+| Semantic Scholar | 可选 | `S2_API_KEY` | 提高速率限制 |
+| PubMed | 可选 | `NCBI_API_KEY` | 限额从 3 req/s 提升到 10 req/s |
+| HuggingFace | 可选 | `HF_TOKEN` | 提高限额 |
+| B 站 | 可选 | `BILIBILI_COOKIE` | 提高结果质量 |
+| 知乎 | **必填** | `ZHIHU_COOKIE` | 不配置无法搜索 |
+| 抖音 | **必填** | `DOUYIN_COOKIE` | 不配置无法搜索 |
+| Twitter/X | **必填** | `TIKHUB_TOKEN` | 通过 TikHub 反代 |
+| YouTube | **必填** | `YOUTUBE_API_KEY` | YouTube Data API v3 |
+
+ArXiv、Stack Overflow、Hacker News、Reddit 公开搜索无需 key。
+
+### 3. Python 依赖
+
+搜索技能未提供独立的 `requirements.txt`，依赖通常已包含在执行环境中。如需自行准备：
+
+```bash
+pip install requests httpx lxml beautifulsoup4
+```
+
+深度研究技能本身不直接调用 HTTP，主要靠 OpenClaw `web_search` 与上面的搜索脚本。
+
+### 4. 在智能体中调用
+
+**深度研究入口**——直接描述研究主题即可触发：
+
+> "深度研究：2025 年家用机器人产业链与主要玩家"
+
+或按名调用：
+
+> /skill deep-research "家用机器人产业链"
+
+**单独使用搜索**——按场景描述需求：
+
+> "搜一下最近关于 RAG 的 ArXiv 论文，按引用数排序"
+> "在 GitHub 上找 Python 实现的 in-context learning 项目"
+
+或按名调用：
+
+> /skill search-academic "retrieval-augmented generation"
+> /skill search-code "in-context learning python"
+> /skill search-social-cn "扩散模型 教程"
+> /skill search-social-en "vision transformer explained"
+
+**深度研究细分阶段**（高级用法）：
+
+> /skill research-planning  # 基于已写好的 request.md 产出 plan.json
+> /skill dimension-research # 按 plan.json 中某个维度做取证
+> /skill research-synthesis # 把已有 sub_reports 综合为 synthesis.md
+> /skill research-report    # 由 synthesis.md 与 sub_reports 落成 report.md
+
+**直接以子进程方式调用搜索脚本**：
+
+```bash
+GITHUB_TOKEN=ghp_xxx python3 skills/search-code/scripts/github_search.py "import asyncio" --type code --limit 5
+ZHIHU_COOKIE="..." python3 skills/search-social-cn/scripts/zhihu_search.py "Python 异步编程" --limit 5
+```
+
+## 输出物
+
+### 深度研究
+
+报告产物默认保存在 `{workspace}/reports/{YYYY-MM-DD}-{slug}-{hex4}/`：
+
+- `request.md` —— 用户原始诉求与边界
+- `plan.json` —— 维度拆解、关键问题、搜索策略、报告形态
+- `sub_reports/d1.md` … `d8.md` —— 各维度证据汇总（含证据表与置信度）
+- `synthesis.md` —— 综合判断（主线、共识、冲突、不确定性）
+- `report.md` —— 最终报告
+
+更多样例参见 [`docs/deep-research-examples.md`](deep-research-examples.md)（待补充）。
+
+### 搜索
+
+所有搜索脚本统一输出 JSON 到 stdout：
+
+```json
+{
+  "success": true,
+  "query": "...",
+  "provider": "...",
+  "items": [
+    {"title": "...", "url": "...", "snippet": "..."}
+  ],
+  "error": null
+}
+```
+
+ArXiv 与 PMC 的全文阅读脚本会返回结构化的章节内容，便于按需读取。

--- a/docs/deep-research_en.md
+++ b/docs/deep-research_en.md
@@ -1,0 +1,143 @@
+# Deep Research & Search Skills
+
+English | [简体中文](deep-research.md)
+
+This document collects the deep-research skills (`deep-research`, `research-planning`, `dimension-research`, `research-synthesis`, `research-report`, `report-format-discovery`) and the search skills (`search-academic`, `search-code`, `search-social-cn`, `search-social-en`).
+
+Deep-research skills handle planning, synthesis, and final writing. Search skills are invoked by `dimension-research` during per-dimension evidence gathering, covering academic papers, developer resources, and Chinese & English social platforms. Together they form an end-to-end pipeline.
+
+## Prerequisites
+
+- **Python** 3.9 or later (3.10+ recommended).
+- **OpenClaw `web_search` must be configured and available** — the deep-research orchestrator gates on it at startup.
+- Optional / required platform API keys depending on the dimensions you research (see [API Keys](#2-api-keys)).
+
+## Deep-Research Skills
+
+| Name | Role | Description |
+|------|------|-------------|
+| [`deep-research`](../skills/deep-research/SKILL.md) | **Deep-research entry** | End-to-end orchestrator: `request.md → plan.json → sub_reports/*.md → synthesis.md → report.md`; artifacts persisted to `report_dir`; supports resume. |
+| [`research-planning`](../skills/research-planning/SKILL.md) | Research planning | Produces `plan.json` from `request.md` in a single pass, covering scope, report shape, dimension breakdown (3–8), key questions, search strategies, dependencies, and completion criteria. |
+| [`dimension-research`](../skills/dimension-research/SKILL.md) | Per-dimension evidence | Calls [search skills](#search-skills) per the dimension's `search_strategy` for multi-round gathering and cross-validation; emits `sub_reports/{dimension_id}.md`. |
+| [`research-synthesis`](../skills/research-synthesis/SKILL.md) | Synthesis & judgment | Synthesizes multiple `sub_reports` into `synthesis.md`: main conclusions, evidence strength, cross-dimension consensus, key conflicts, and uncertainties. |
+| [`research-report`](../skills/research-report/SKILL.md) | Final writing / rewriting | Turns the judgment layer into final `report.md`; also supports targeted edits on existing reports (rewrite, polish, restructure, add tables). |
+| [`report-format-discovery`](../skills/report-format-discovery/SKILL.md) | Report-format discovery | Researches what such a report typically looks like, returning section structure, mandatory elements, and style constraints; usable standalone or as input for `deep-research`'s `report_shape`. |
+
+## Search Skills
+
+| Name | Role | Description |
+|------|------|-------------|
+| [`search-academic`](../skills/search-academic/SKILL.md) | Academic search | ArXiv (with section-by-section HTML full-text reading) / Semantic Scholar (citation counts and forward/backward citation chains) / PubMed (with PMC open-access full text) / Wikipedia (multi-language). |
+| [`search-code`](../skills/search-code/SKILL.md) | Developer search | GitHub (repos / code / issues) / Stack Overflow (by tag / votes) / HuggingFace (models / datasets / Spaces) / Hacker News. |
+| [`search-social-cn`](../skills/search-social-cn/SKILL.md) | Chinese social search | Bilibili / Zhihu / Douyin; Zhihu and Douyin require cookies, Bilibili cookie is optional. |
+| [`search-social-en`](../skills/search-social-en/SKILL.md) | English social search | Reddit (subreddit / sort / time range) / Twitter (X) (via TikHub) / YouTube (API key). |
+
+`_search-common` is a shared utility module (`search_utils.py`) used by the other search skills; it is not user-facing.
+
+## Quick Start
+
+Use these skills from [OpenClaw](https://openclaw.ai/). For skill registration steps, see [`u1-image-generate_en.md`](u1-image-generate_en.md#1-register-skills).
+
+### 1. Hard precheck: `web_search`
+
+Before creating `report_dir`, writing `request.md`, or entering any research stage, `deep-research` **must confirm that OpenClaw `web_search` is currently available**. Do not start research — and do not substitute memory/prior knowledge for online evidence — until this is confirmed.
+
+- Static check: `tools.web.search.provider` and `plugins.entries.<plugin>.config.webSearch.*` are configured
+- If unsure, issue a minimal `web_search` probe; proceed on success; stop on missing key, provider not ready, service unreachable, or `search disabled`
+
+### 2. API Keys
+
+Set as needed in `~/.openclaw/.env` (or `~/.hermes/.env`):
+
+| Platform | Required / Optional | Env var | Notes |
+|----------|--------|---------|-------|
+| GitHub repo/issue search | Optional (rate-limit boost) | `GITHUB_TOKEN` | Anonymous works for public search |
+| GitHub code search | **Required** | `GITHUB_TOKEN` | Mandatory for `--type code` |
+| Semantic Scholar | Optional | `S2_API_KEY` | Rate-limit boost |
+| PubMed | Optional | `NCBI_API_KEY` | Lifts cap from 3 req/s to 10 req/s |
+| HuggingFace | Optional | `HF_TOKEN` | Rate-limit boost |
+| Bilibili | Optional | `BILIBILI_COOKIE` | Improves result quality |
+| Zhihu | **Required** | `ZHIHU_COOKIE` | Search will not work without it |
+| Douyin | **Required** | `DOUYIN_COOKIE` | Search will not work without it |
+| Twitter/X | **Required** | `TIKHUB_TOKEN` | Routed via TikHub |
+| YouTube | **Required** | `YOUTUBE_API_KEY` | YouTube Data API v3 |
+
+ArXiv, Stack Overflow, Hacker News, and Reddit public search require no key.
+
+### 3. Python dependencies
+
+Search skills do not ship a per-skill `requirements.txt`; deps are typically present in the base execution image. If preparing a fresh environment:
+
+```bash
+pip install requests httpx lxml beautifulsoup4
+```
+
+Deep-research skills do not call HTTP directly — they rely on OpenClaw `web_search` and the search scripts above.
+
+### 4. Invoke in Agent
+
+**Deep-research entry** — describe the topic to trigger:
+
+> "Deep research: home robotics supply chain and key players in 2025"
+
+Or call by name:
+
+> /skill deep-research "Home robotics supply chain"
+
+**Standalone search** — describe the request:
+
+> "Find recent ArXiv papers on RAG, sorted by citation count"
+> "Search GitHub for Python implementations of in-context learning"
+
+Or call by name:
+
+> /skill search-academic "retrieval-augmented generation"
+> /skill search-code "in-context learning python"
+> /skill search-social-cn "扩散模型 教程"
+> /skill search-social-en "vision transformer explained"
+
+**Per-stage deep-research invocation** (advanced):
+
+> /skill research-planning  # produce plan.json from a written request.md
+> /skill dimension-research # gather evidence for a specific dimension in plan.json
+> /skill research-synthesis # synthesize existing sub_reports into synthesis.md
+> /skill research-report    # write report.md from synthesis.md + sub_reports
+
+**Directly invoking search scripts as subprocesses**:
+
+```bash
+GITHUB_TOKEN=ghp_xxx python3 skills/search-code/scripts/github_search.py "import asyncio" --type code --limit 5
+ZHIHU_COOKIE="..." python3 skills/search-social-cn/scripts/zhihu_search.py "Python 异步编程" --limit 5
+```
+
+## Outputs
+
+### Deep Research
+
+Report artifacts are written to `{workspace}/reports/{YYYY-MM-DD}-{slug}-{hex4}/`:
+
+- `request.md` — original user request and scope
+- `plan.json` — dimension breakdown, key questions, search strategies, report shape
+- `sub_reports/d1.md` … `d8.md` — per-dimension evidence (with evidence table and confidence)
+- `synthesis.md` — synthesis (main lines, consensus, conflicts, uncertainty)
+- `report.md` — final report
+
+More samples: [`docs/deep-research-examples.md`](deep-research-examples.md) (TBD).
+
+### Search
+
+All search scripts emit JSON to stdout in a unified shape:
+
+```json
+{
+  "success": true,
+  "query": "...",
+  "provider": "...",
+  "items": [
+    {"title": "...", "url": "...", "snippet": "..."}
+  ],
+  "error": null
+}
+```
+
+ArXiv and PMC full-text readers additionally return structured section content for incremental reading.

--- a/docs/ppt-generate.md
+++ b/docs/ppt-generate.md
@@ -1,0 +1,82 @@
+# PPT 生成相关技能
+
+简体中文 | [English](ppt-generate_en.md)
+
+本文档汇总演示文稿（PPT）生成相关技能（`ppt-entry`、`ppt-doctor`、`ppt-creative`、`ppt-standard`），用于在 OpenClaw / Hermes 中按用户需求生成 PPTX 文件。
+
+## 环境要求
+
+- **Python** 3.9 或更高版本（推荐 3.10+）。
+- **Node.js** 运行时（`ppt-standard` 在分页 HTML 处理阶段使用）。
+- 需要 LLM/VLM 与文生图 API 凭据（详见下文）。
+
+## 技能介绍
+
+| 名称 | 角色 | 说明 |
+|------|------|------|
+| [`ppt-entry`](../skills/ppt-entry/SKILL.md) | **PPT 入口** | 收集角色 / 受众 / 场景 / 页数 / 模式（创意 or 标准），解析 pdf / docx / md / txt 输入，产出 `task_pack.json` + `info_pack.json` 并分派到下游模式。 |
+| [`ppt-doctor`](../skills/ppt-doctor/SKILL.md) | PPT 环境诊断 | 验证 `u1-image-base` 可用性、API key、Node 运行时与可选依赖；按需写入 `.env`。 |
+| [`ppt-creative`](../skills/ppt-creative/SKILL.md) | PPT 创意模式 | 每页一张 16:9 全图（PNG），按页面构图 prompt 走 `u1-image-generate` 一次性出图后导出 PPTX。 |
+| [`ppt-standard`](../skills/ppt-standard/SKILL.md) | PPT 标准模式 | `style_spec` → 大纲 → 资产规划 + 分槽位图像 + VLM 质检 → 分页 HTML → 分页评审（可选重写）→ 汇总 `review.md` → 导出 PPTX。 |
+
+`ppt-creative` 依赖 `u1-image-base` 进行文生图；`ppt-standard` 自带模型调用脚本（`scripts/run_stage.py`）。
+
+## Quick Start
+
+通过 [OpenClaw](https://openclaw.ai/) 使用这些技能。技能注册（拷贝 / 软链 / `openclaw.json` 三种方式）请参考 [`u1-image-generate.md`](u1-image-generate.md#1-注册技能) 中的对应章节，本文档不再赘述。
+
+### 1. Python 依赖
+
+```bash
+# ppt-entry：解析 PDF / DOCX
+pip install -r skills/ppt-entry/requirements.txt
+
+# ppt-creative：导出 PPTX
+pip install -r skills/ppt-creative/requirements.txt
+
+# ppt-creative 依赖 u1-image-base 的图像生成接口
+pip install -r skills/u1-image-base/requirements.txt
+```
+
+`ppt-doctor` 仅用 Python 标准库，无需额外依赖。`ppt-standard` 在 `scripts/run_stage.py` 中包装模型调用，最终导出 PPTX 同样需要 `python-pptx`。
+
+### 2. API Key 与环境变量
+
+将以下变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
+
+```ini
+# LLM（大纲、style_spec、内容规划）
+U1_LM_API_KEY="your-api-key"
+U1_LM_BASE_URL="https://token.sensenova.cn/v1"
+
+# 文生图（创意模式必填，标准模式按需）
+U1_API_KEY="your-api-key"
+```
+
+可选环境变量：`U1_IMAGE_GEN_*`、`VLM_*`、`LLM_*` 用于覆盖默认模型与超时。详细列表见 [`skills/u1-image-base/README.md`](../skills/u1-image-base/README.md)。
+
+调用前先运行环境诊断：
+
+> 运行 `ppt-doctor` 技能
+
+### 3. 在智能体中调用
+
+`ppt-entry` 是统一入口，会自动调度到 creative 或 standard 模式：
+
+> "做一份关于团队 OKR 的 10 页 PPT，受众是高管，风格简洁"
+
+或直接按名调用：
+
+> /skill ppt-entry "团队 OKR 汇报"
+
+## 输出物
+
+PPT 产物默认保存在 `$(pwd)/ppt_decks/<topic>_<timestamp>/`，目录内包含：
+
+- `task_pack.json` / `info_pack.json` —— `ppt-entry` 解析后的任务参数
+- `style_spec.md`、`outline.json` —— 风格与大纲（标准模式）
+- `pages/page_*.png` —— 单页全图（创意模式）或 HTML 渲染图（标准模式）
+- `review.md` —— 分页评审汇总（标准模式）
+- `<deck_id>.pptx` —— 最终 PPTX
+
+更多样例参见 [`docs/ppt-examples.md`](ppt-examples.md)（待补充）。

--- a/docs/ppt-generate_en.md
+++ b/docs/ppt-generate_en.md
@@ -1,0 +1,82 @@
+# PPT Generation Skills
+
+English | [简体中文](ppt-generate.md)
+
+This document collects the PPT generation skills (`ppt-entry`, `ppt-doctor`, `ppt-creative`, `ppt-standard`) used in OpenClaw / Hermes to produce `.pptx` decks from user prompts and reference documents.
+
+## Prerequisites
+
+- **Python** 3.9 or later (3.10+ recommended).
+- **Node.js** runtime (used by `ppt-standard` during per-page HTML processing).
+- LLM/VLM and text-to-image API credentials (see below).
+
+## Skills
+
+| Name | Role | Description |
+|------|------|-------------|
+| [`ppt-entry`](../skills/ppt-entry/SKILL.md) | **PPT entry** | Collects role / audience / scene / page count / mode (creative or standard), parses pdf / docx / md / txt inputs, emits `task_pack.json` + `info_pack.json`, and dispatches to a downstream mode. |
+| [`ppt-doctor`](../skills/ppt-doctor/SKILL.md) | PPT environment doctor | Validates `u1-image-base` availability, API keys, Node runtime, and optional deps; writes missing required vars into `.env`. |
+| [`ppt-creative`](../skills/ppt-creative/SKILL.md) | PPT creative mode | One full-page 16:9 PNG per slide, generated via `u1-image-generate` from a per-page composed prompt; exports PPTX. |
+| [`ppt-standard`](../skills/ppt-standard/SKILL.md) | PPT standard mode | `style_spec` → outline → asset plan + per-slot images + VLM QA → per-page HTML → per-page review (optional rewrite) → summary `review.md` → PPTX export. |
+
+`ppt-creative` depends on `u1-image-base` for text-to-image; `ppt-standard` ships its own model invocation scripts (`scripts/run_stage.py`).
+
+## Quick Start
+
+Use these skills from [OpenClaw](https://openclaw.ai/). For the generic skill registration steps (copy / symlink / `openclaw.json`), see [`u1-image-generate_en.md`](u1-image-generate_en.md#1-register-skills); they are not repeated here.
+
+### 1. Python dependencies
+
+```bash
+# ppt-entry: PDF / DOCX parsing
+pip install -r skills/ppt-entry/requirements.txt
+
+# ppt-creative: PPTX export
+pip install -r skills/ppt-creative/requirements.txt
+
+# ppt-creative also needs u1-image-base's image generation runtime
+pip install -r skills/u1-image-base/requirements.txt
+```
+
+`ppt-doctor` uses only the Python stdlib. `ppt-standard` wraps model calls in `scripts/run_stage.py` and also requires `python-pptx` for the final PPTX export.
+
+### 2. API keys and environment variables
+
+Set the following in `~/.openclaw/.env` (OpenClaw) or `~/.hermes/.env` (Hermes):
+
+```ini
+# LLM (outline, style_spec, content planning)
+U1_LM_API_KEY="your-api-key"
+U1_LM_BASE_URL="https://token.sensenova.cn/v1"
+
+# Text-to-image (required for creative mode, on-demand for standard mode)
+U1_API_KEY="your-api-key"
+```
+
+Optional variables `U1_IMAGE_GEN_*`, `VLM_*`, `LLM_*` override default models and timeouts. Full list: [`skills/u1-image-base/README.md`](../skills/u1-image-base/README.md).
+
+Run environment doctor before invoking:
+
+> Run the `ppt-doctor` skill
+
+### 3. Invoke in Agent
+
+`ppt-entry` is the unified entry point and dispatches to creative or standard mode automatically:
+
+> "Make a 10-page deck on team OKRs for an executive audience, minimalist style"
+
+Or call by name:
+
+> /skill ppt-entry "Team OKR review"
+
+## Outputs
+
+Decks are written to `$(pwd)/ppt_decks/<topic>_<timestamp>/`, containing:
+
+- `task_pack.json` / `info_pack.json` — parsed task parameters from `ppt-entry`
+- `style_spec.md`, `outline.json` — style and outline (standard mode)
+- `pages/page_*.png` — full-page images (creative) or HTML-rendered slides (standard)
+- `review.md` — per-page review summary (standard mode)
+- `<deck_id>.pptx` — final PPTX
+
+More samples: [`docs/ppt-examples.md`](ppt-examples.md) (TBD).

--- a/docs/u1-image-generate.md
+++ b/docs/u1-image-generate.md
@@ -1,0 +1,203 @@
+# U1 图像生成相关技能
+
+简体中文 | [English](u1-image-generate_en.md)
+
+本文档汇总 U1 相关技能（`u1-doctor`、`u1-image-base`、`u1-infographic`），并提供在 OpenClaw / Hermes 中端到端使用这些技能的 Quick Start。
+
+## 环境要求
+
+- **Python** 3.9 或更高版本（推荐 3.10+）。
+- **U1 API** 凭据，用于图像生成与 LLM/VLM 接口（`U1_API_KEY`、`U1_LM_API_KEY`，详见 Quick Start）。
+
+## 技能介绍
+
+### u1-doctor
+
+环境诊断技能，检查安装、依赖与配置。完整行为见 [`skills/u1-doctor/SKILL.md`](../skills/u1-doctor/SKILL.md)。
+
+- 校验 `u1-image-base` 安装与 Python 依赖
+- 检查环境变量，对缺失的必填项交互式补齐
+- 自动写入 `.env` 并重新加载环境
+
+### u1-image-base（Tier 0）
+
+底层基础设施技能，提供图像生成、图像识别（VLM）与文本优化（LLM）的低级工具。完整行为见 [`skills/u1-image-base/SKILL.md`](../skills/u1-image-base/SKILL.md)。
+
+- **u1-image-generate** —— 文生图（调用 text-to-image 接口）
+- **u1-image-recognize** —— 图像识别，使用 VLM 解析图像内容（支持多图输入）
+- **u1-text-optimize** —— 基于 LLM 的文本优化与处理
+
+所有工具统一通过 `openclaw_runner.py` 入口调用。
+
+### u1-infographic（Tier 1）
+
+构建于 `u1-image-base` 之上的场景技能，用于生成专业级信息图。完整行为见 [`skills/u1-infographic/SKILL.md`](../skills/u1-infographic/SKILL.md)。
+
+- 自动评估提示词质量
+- 内容分析与版式 / 风格选型（87 种布局、66 种风格）
+- 多轮生成 + VLM 评审
+- 质量排序并输出最优结果
+
+## Quick Start
+
+通过 [OpenClaw](https://openclaw.ai/) 使用这些技能。
+它们遵循 [Agent Skills](https://agentskills.io/) 规范；OpenClaw 如何发现并加载技能目录，参见 [OpenClaw Skills](https://docs.openclaw.ai/tools/skills)。
+如果尚未配置 OpenClaw，请先按 **[官方文档](https://docs.openclaw.ai/)** 安装与配置（产品站点：[openclaw.ai](https://openclaw.ai/)）。
+
+### 1. 注册技能
+
+克隆本仓库，然后将 `skills/` 目录暴露给 OpenClaw（参考 [位置与优先级](https://docs.openclaw.ai/tools/skills#locations-and-precedence)）或 Hermes。
+
+可选以下任一方式：
+
+| 方式 | 操作 |
+|------|------|
+| **本机共享** | 把 `skills/` 下的子目录拷贝或软链接到 `~/.openclaw/skills/`（OpenClaw）或 `~/.hermes/skills/openclaw-imports/`（Hermes）。 |
+| **工作区 `skills/`** | 把 `skills/u1-image-base`、`skills/u1-infographic`、`skills/u1-doctor` 拷贝或软链接到智能体工作区。 |
+| **`openclaw.json`（仅 OpenClaw）** | 通过 `skills.load.extraDirs` 添加本仓库 `skills` 目录的绝对路径（即所有技能子目录的父目录，示例如下）。 |
+
+```json5
+{
+  skills: {
+    load: {
+      extraDirs: ["/absolute/path/to/SenseNova-Skills/skills"],
+    },
+  },
+}
+```
+
+请把路径替换为本地克隆位置。详情见 [Skills config](https://docs.openclaw.ai/tools/skills-config)。如果同名技能在工作区与 `extraDirs` 中同时存在，工作区版本优先。
+
+### 2. Python 依赖与 API Key
+
+在 OpenClaw 运行 [`skills/u1-image-base/u1_image_base/openclaw_runner.py`](../skills/u1-image-base/u1_image_base/openclaw_runner.py)（这些工具的统一入口）所使用的 **Python 环境与进程** 中，安装依赖并导出 API Key：
+
+```bash
+pip install -r skills/u1-image-base/requirements.txt
+```
+
+**最小化配置：**
+
+推荐使用 [SenseNova Token Plan](https://platform.sensenova.cn/token-plan) 来配置这些技能。
+
+前往 <https://platform.sensenova.cn/token-plan/> 注册免费账号并获取 API Key。
+
+将以下环境变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
+
+```ini
+U1_API_KEY="your-api-key"
+U1_LM_API_KEY="your-api-key"
+```
+
+**注意：** 切勿将 `.env` 或 API Key 提交到 git。
+
+**进阶配置：**
+
+如果你想在文生图中使用其他模型（例如 Nano Banana、GPT-Image-2），或在 LLM/VLM 中使用其他模型（例如 GPT、Claude Sonnet 4.6），
+请参考 [`skills/u1-image-base/README.md`](../skills/u1-image-base/README.md) 中的详细配置说明。
+
+### 3. 在智能体中调用
+
+使用前先检查环境变量：
+
+> 运行 `u1-doctor` 技能
+
+在对话中描述任务，例如：
+
+> "做一张解释水循环的信息图"
+
+或按名调用技能：
+
+> /skill u1-infographic "水循环"
+
+## 输出样例
+
+`u1-infographic` 的样例（更多样例见 [`u1-infographic-examples_CN.md`](u1-infographic-examples_CN.md)）。
+
+### 样例 1
+
+**用户输入：** `"HEALTH_CHECK_PROMO"`
+
+#### 扩写后的提示词
+
+```text
+The infographic is titled "HEALTH_CHECK_PROMO.exe", styled as a retro computer application window with a pink title bar and standard window controls (close, minimize, maximize) in the top-right corner. The overall design mimics a 90s-era software interface with a grid background, pixelated icons, and bold, colorful sections. The primary color scheme includes bright yellow, purple, pink, blue, and green, creating a high-contrast, energetic aesthetic.
+
+At the top, under the title bar, is a section labeled "Campaign Info" with fields for "Event Name:", "Date:", and "Coordinator:". Adjacent to this is an "HP Loading Bar" with a red heart icon, showing a segmented progress bar filled with green, yellow, and pink segments—indicating health or completion status.
+
+Below this header, the main content is organized into three vertical columns representing a workflow:
+
+1. **TO PROMOTE** (pink background):
+   - Header: "TO PROMOTE" with a red circle labeled "Urgent".
+   - Contains three blank rectangular input boxes.
+   - Decorated with pixelated yellow band-aids and arrows indicating movement or prioritization.
+   - A ">>>" symbol at the bottom suggests progression.
+
+2. **LIVE DOING** (blue background):
+   - Header: "LIVE DOING" with a yellow circle labeled "In-Progress".
+   - Contains three blank rectangular input boxes.
+   - Each box has small black or yellow squares on the left, possibly indicating status or priority.
+   - Pixelated white cursor icons with sparkles point toward each box, suggesting active tasks.
+
+3. **PUBLISHED** (yellow background):
+   - Header: "PUBLISHED" with a green circle labeled "Healthy/Published".
+   - Contains three blank rectangular input boxes.
+   - Each box has a pink checkmark and a "DONE" stamp in the bottom-right corner, signifying completion.
+
+Beneath these columns is a section titled "Media Milestones", displayed as a horizontal timeline with a black electrocardiogram (ECG) line. Three pixelated red hearts mark key points along the ECG:
+
+- **Milestone 1: Pre-heat**
+- **Milestone 2: Live Coverage**
+- **Milestone 3: Recap & Insights**
+
+Each milestone is linked to a blank rectangular box below for additional notes or details.
+
+At the bottom of the infographic are two side-by-side panels:
+
+- **Med-Team** (pink header):
+  - Contains four circular placeholder icons for team members, each with a plus sign above or below, indicating expandability or addition.
+  - Standard window controls (minimize, maximize, close) are present in the top-right.
+
+- **Blockers** (pink header):
+  - Contains a single green pixelated virus/bug icon with a skull face, symbolizing obstacles or issues.
+  - Also includes window controls in the top-right.
+
+The entire layout is framed by decorative elements: pixelated red crosses (like medical symbols), a pixelated hand cursor on the right, and scattered pixelated handheld gaming devices (resembling Game Boys) in pink and yellow. The background features a split of bright yellow and purple with grid patterns, reinforcing the retro digital theme.
+
+All text is rendered in a bold, pixelated font consistent with early computer graphics. No numerical data beyond the segment counts in the HP bar is explicitly presented; all values are categorical or qualitative. The infographic serves as a dynamic, gamified project management tool for tracking promotional campaigns.
+```
+
+![信息图样例 — HEALTH_CHECK_PROMO](images/demo8.webp)
+
+### 样例 2｜流媒体：无界分发
+
+**用户输入：** `"流媒体：无界分发"`
+
+#### 扩写后的提示词
+
+```text
+信息图以赛博朋克风格的未来都市为视觉背景，整体采用垂直三段式布局，通过动态画面、科技元素与文字叠加，系统呈现"流媒体：无界分发"的核心主题。主色调为深蓝、紫粉与霓虹青色，营造出雨夜中数据流动的沉浸感，配合大量悬浮屏幕、发光管道与电子符号，强化科技氛围。
+
+顶部标题为"流媒体：无界分发"，字体采用粗体无衬线字型，边缘带有青紫渐变光晕，置于黑色背景条上，极具视觉冲击力。
+
+第一部分（上部）：
+- 背景：高耸摩天大楼林立，布满悬挂式透明显示屏，播放着人物影像或界面内容，部分屏幕可见YouTube图标与视频播放进度条。
+- 文字框1："在矩阵中，每一次播放，都是跨越终端的灵魂共振。"位于左下方，背景为黑底青边，左侧标注"云端节点"。
+- 视觉细节：建筑上有中文霓虹招牌如"云造街道"、"超清深潜"、"酒"、"食"等，增强场景真实感。
+
+第二部分（中部）：
+- 主体角色：一位女性赛博格形象，身穿紧身高科技战甲，面部有蓝色数据投影，机械臂握持带电蓝色管线，电流闪烁。
+- 面部投影文字包括："106.750.25&"、"BVB434E"、"B4V69G"、"65365818"、"HOOA: E3R 6Z8"、"000 0X-E4"等模拟数据流。
+- 文字框2："我能看见每一帧跳动的像素底色。"位于角色右侧，黑底白字，青边框。
+- 文字框3："解码协议：8K 120fps……无缓冲渲染成功。"位于左下角，黑底白字，青边框，左侧标注"超清深潜"。
+
+第三部分（下部）：
+- 动态场景：同一位女性角色在城市高速飞行，身后拖曳紫色光轨，前方是巨大发光"SHARE"标志。
+- 右侧可视化网络结构：从"SHARE"出发，辐射出多个P2P节点与文件图标（如PDF、MP4、ZIP），用闪电状线条连接，象征数据分发网络。
+- 文字框4："点击分享，让视界呈指数级扩散。"位于左下角，黑底白字，青边框，下方标注"全网广播"。
+- 文字框5："多端同步通道已全域开启。"位于右下角，黑底白字，青边框。
+
+整体设计融合了科幻美学与技术叙事，通过三个递进场景——云端传输、超清解码、全球共享——构建完整流媒体服务链条，所有文本均为中文，语言风格充满未来感与诗意，精准传达"无界分发"的技术愿景。
+```
+
+![信息图样例 — 流媒体：无界分发](images/demo2.webp)

--- a/docs/u1-image-generate_en.md
+++ b/docs/u1-image-generate_en.md
@@ -1,0 +1,203 @@
+# U1 Image Generation Skills
+
+English | [简体中文](u1-image-generate.md)
+
+This document collects the U1-related skills (`u1-doctor`, `u1-image-base`, `u1-infographic`) and the end-to-end Quick Start for using them in OpenClaw / Hermes.
+
+## Prerequisites
+
+- **Python** 3.9 or later (3.10+ recommended).
+- **U1 API** credentials for image generation and LLM/VLM endpoints (`U1_API_KEY`, `U1_LM_API_KEY`; see Quick Start).
+
+## Skills
+
+### u1-doctor
+
+Environment diagnostic skill that checks installation, dependencies, and configuration. See [`skills/u1-doctor/SKILL.md`](../skills/u1-doctor/SKILL.md) for full behavior.
+
+- Validates `u1-image-base` installation and Python dependencies
+- Checks environment variables and interactively prompts to configure missing required variables
+- Saves configuration to `.env` file and reloads environment automatically
+
+### u1-image-base (Tier 0)
+
+Base-layer infrastructure skill providing low-level tools for image generation, image recognition (VLM), and text optimization (LLM). See [`skills/u1-image-base/SKILL.md`](../skills/u1-image-base/SKILL.md) for full behavior.
+
+- **u1-image-generate** — text-to-image generation
+- **u1-image-recognize** — image recognition using VLM (supports multiple image inputs)
+- **u1-text-optimize** — text processing/optimization using LLM
+
+All tools are invoked through a unified `openclaw_runner.py` entrypoint.
+
+### u1-infographic (Tier 1)
+
+Scene skill for generating professional infographics, built on `u1-image-base`. See [`skills/u1-infographic/SKILL.md`](../skills/u1-infographic/SKILL.md) for full behavior.
+
+- Automatic prompt quality evaluation
+- Content analysis and layout/style selection (87 layouts, 66 styles)
+- Multi-round image generation with VLM review
+- Quality ranking and best-result output
+
+## Quick Start
+
+Use these skills from [OpenClaw](https://openclaw.ai/).
+They follow the [Agent Skills](https://agentskills.io/) layout; see [OpenClaw Skills](https://docs.openclaw.ai/tools/skills) for how OpenClaw discovers and loads skill folders.
+If you have not set up OpenClaw yet, install and configure it from the **[official documentation](https://docs.openclaw.ai/)** (product site: [openclaw.ai](https://openclaw.ai/)).
+
+### 1. Register skills
+
+Clone this repository, then expose the `skills/` directory to OpenClaw ([locations and precedence](https://docs.openclaw.ai/tools/skills#locations-and-precedence)) (or Hermes).
+
+Use one of the following approaches:
+
+| Approach | What to do |
+|----------|------------|
+| **Shared on this machine** | Copy or symlink subdirectories under `skills/` to `~/.openclaw/skills/` (OpenClaw) or `~/.hermes/skills/openclaw-imports/` (Hermes). |
+| **Workspace `skills/`** | Copy or symlink `skills/u1-image-base`, `skills/u1-infographic`, and `skills/u1-doctor` into your agent workspace. |
+| **`openclaw.json` (OpenClaw only)** | Add an absolute path to this repo's `skills` folder (the parent of all skill directories) via `skills.load.extraDirs` (example below). |
+
+```json5
+{
+  skills: {
+    load: {
+      extraDirs: ["/absolute/path/to/SenseNova-Skills/skills"],
+    },
+  },
+}
+```
+
+Replace the path with your clone. Details: [Skills config](https://docs.openclaw.ai/tools/skills-config). Workspace skills win over `extraDirs` if the same name appears twice.
+
+### 2. Python dependencies and API keys
+
+Install packages and export keys in the **Python environment and process** OpenClaw uses when it runs [`skills/u1-image-base/u1_image_base/openclaw_runner.py`](../skills/u1-image-base/u1_image_base/openclaw_runner.py) (the unified runner for these tools):
+
+```bash
+pip install -r skills/u1-image-base/requirements.txt
+```
+
+**Minimum Configurations:**
+
+We recommend you to try out our [SenseNova Token Plan](https://platform.sensenova.cn/token-plan) to setup these skills.
+
+Go to <https://platform.sensenova.cn/token-plan/> to register a free account and get your API key.
+
+Set the following environment variables in `~/.openclaw/.env` (for OpenClaw) or `~/.hermes/.env` (for Hermes):
+
+```ini
+U1_API_KEY="your-api-key"
+U1_LM_API_KEY="your-api-key"
+```
+
+**Note:** Never commit `.env` files or API keys to git.
+
+**Advanced Configurations:**
+
+If you want to use different models for image generation (e.g. Nano Banana, GPT-Image-2) and LLM/VLM (e.g. GPT, Claude Sonnet 4.6),
+Please see [`skills/u1-image-base/README.md`](../skills/u1-image-base/README.md) for detailed configurations.
+
+### 3. Invoke in Agent
+
+Check your environment variables before using the skills:
+
+> Run the `u1-doctor` skill
+
+Describe the task in chat, for example:
+
+> "Create an infographic explaining the water cycle"
+
+Or call the skill by name:
+
+> /skill u1-infographic "The water cycle"
+
+## Sample Outputs
+
+Examples for `u1-infographic` (more examples in [`u1-infographic-examples.md`](u1-infographic-examples.md)).
+
+### Example 1
+
+**User prompt:** `"HEALTH_CHECK_PROMO"`
+
+#### Expanded prompt
+
+```text
+The infographic is titled "HEALTH_CHECK_PROMO.exe", styled as a retro computer application window with a pink title bar and standard window controls (close, minimize, maximize) in the top-right corner. The overall design mimics a 90s-era software interface with a grid background, pixelated icons, and bold, colorful sections. The primary color scheme includes bright yellow, purple, pink, blue, and green, creating a high-contrast, energetic aesthetic.
+
+At the top, under the title bar, is a section labeled "Campaign Info" with fields for "Event Name:", "Date:", and "Coordinator:". Adjacent to this is an "HP Loading Bar" with a red heart icon, showing a segmented progress bar filled with green, yellow, and pink segments—indicating health or completion status.
+
+Below this header, the main content is organized into three vertical columns representing a workflow:
+
+1. **TO PROMOTE** (pink background):
+   - Header: "TO PROMOTE" with a red circle labeled "Urgent".
+   - Contains three blank rectangular input boxes.
+   - Decorated with pixelated yellow band-aids and arrows indicating movement or prioritization.
+   - A ">>>" symbol at the bottom suggests progression.
+
+2. **LIVE DOING** (blue background):
+   - Header: "LIVE DOING" with a yellow circle labeled "In-Progress".
+   - Contains three blank rectangular input boxes.
+   - Each box has small black or yellow squares on the left, possibly indicating status or priority.
+   - Pixelated white cursor icons with sparkles point toward each box, suggesting active tasks.
+
+3. **PUBLISHED** (yellow background):
+   - Header: "PUBLISHED" with a green circle labeled "Healthy/Published".
+   - Contains three blank rectangular input boxes.
+   - Each box has a pink checkmark and a "DONE" stamp in the bottom-right corner, signifying completion.
+
+Beneath these columns is a section titled "Media Milestones", displayed as a horizontal timeline with a black electrocardiogram (ECG) line. Three pixelated red hearts mark key points along the ECG:
+
+- **Milestone 1: Pre-heat**
+- **Milestone 2: Live Coverage**
+- **Milestone 3: Recap & Insights**
+
+Each milestone is linked to a blank rectangular box below for additional notes or details.
+
+At the bottom of the infographic are two side-by-side panels:
+
+- **Med-Team** (pink header):
+  - Contains four circular placeholder icons for team members, each with a plus sign above or below, indicating expandability or addition.
+  - Standard window controls (minimize, maximize, close) are present in the top-right.
+
+- **Blockers** (pink header):
+  - Contains a single green pixelated virus/bug icon with a skull face, symbolizing obstacles or issues.
+  - Also includes window controls in the top-right.
+
+The entire layout is framed by decorative elements: pixelated red crosses (like medical symbols), a pixelated hand cursor on the right, and scattered pixelated handheld gaming devices (resembling Game Boys) in pink and yellow. The background features a split of bright yellow and purple with grid patterns, reinforcing the retro digital theme.
+
+All text is rendered in a bold, pixelated font consistent with early computer graphics. No numerical data beyond the segment counts in the HP bar is explicitly presented; all values are categorical or qualitative. The infographic serves as a dynamic, gamified project management tool for tracking promotional campaigns.
+```
+
+![Sample infographic output — HEALTH_CHECK_PROMO](images/demo8.webp)
+
+### Example 2｜Streaming Media: Borderless Distribution
+
+**User prompt:** `"流媒体：无界分发"`
+
+#### Expanded prompt
+
+```text
+信息图以赛博朋克风格的未来都市为视觉背景，整体采用垂直三段式布局，通过动态画面、科技元素与文字叠加，系统呈现"流媒体：无界分发"的核心主题。主色调为深蓝、紫粉与霓虹青色，营造出雨夜中数据流动的沉浸感，配合大量悬浮屏幕、发光管道与电子符号，强化科技氛围。
+
+顶部标题为"流媒体：无界分发"，字体采用粗体无衬线字型，边缘带有青紫渐变光晕，置于黑色背景条上，极具视觉冲击力。
+
+第一部分（上部）：
+- 背景：高耸摩天大楼林立，布满悬挂式透明显示屏，播放着人物影像或界面内容，部分屏幕可见YouTube图标与视频播放进度条。
+- 文字框1："在矩阵中，每一次播放，都是跨越终端的灵魂共振。"位于左下方，背景为黑底青边，左侧标注"云端节点"。
+- 视觉细节：建筑上有中文霓虹招牌如"云造街道"、"超清深潜"、"酒"、"食"等，增强场景真实感。
+
+第二部分（中部）：
+- 主体角色：一位女性赛博格形象，身穿紧身高科技战甲，面部有蓝色数据投影，机械臂握持带电蓝色管线，电流闪烁。
+- 面部投影文字包括："106.750.25&"、"BVB434E"、"B4V69G"、"65365818"、"HOOA: E3R 6Z8"、"000 0X-E4"等模拟数据流。
+- 文字框2："我能看见每一帧跳动的像素底色。"位于角色右侧，黑底白字，青边框。
+- 文字框3："解码协议：8K 120fps……无缓冲渲染成功。"位于左下角，黑底白字，青边框，左侧标注"超清深潜"。
+
+第三部分（下部）：
+- 动态场景：同一位女性角色在城市高速飞行，身后拖曳紫色光轨，前方是巨大发光"SHARE"标志。
+- 右侧可视化网络结构：从"SHARE"出发，辐射出多个P2P节点与文件图标（如PDF、MP4、ZIP），用闪电状线条连接，象征数据分发网络。
+- 文字框4："点击分享，让视界呈指数级扩散。"位于左下角，黑底白字，青边框，下方标注"全网广播"。
+- 文字框5："多端同步通道已全域开启。"位于右下角，黑底白字，青边框。
+
+整体设计融合了科幻美学与技术叙事，通过三个递进场景——云端传输、超清解码、全球共享——构建完整流媒体服务链条，所有文本均为中文，语言风格充满未来感与诗意，精准传达"无界分发"的技术愿景。
+```
+
+![Sample infographic output — Streaming Media: Borderless Distribution](images/demo2.webp)


### PR DESCRIPTION
## Summary
- Add 8 new docs under `docs/` (CN default + EN counterpart per category) covering setup, API keys, and invocation:
  - `u1-image-generate.md` / `_en.md` — image & visualization (U1 skills)
  - `ppt-generate.md` / `_en.md` — presentation generation
  - `data-analysis.md` / `_en.md` — Excel / large-file / image data analysis
  - `deep-research.md` / `_en.md` — deep research orchestration + search skills (merged so the per-platform search keys live next to the `dimension-research` stage that uses them)
- Link each doc from its `## 技能列表` / `## Skills List` section in `README.md` and `README_en.md`.
- Correct the `u1-image-base` row in both READMEs to list all three tools (`u1-image-generate`, `u1-image-recognize`, `u1-text-optimize`); the previous description omitted `u1-image-recognize`.

Each doc cross-checked against the corresponding `skills/<name>/SKILL.md` (skill content takes precedence on conflicts). The U1 doc preserves Quick Start content from the prior English README; the other category docs are new.

## Test plan
- [ ] Open the PR diff on GitHub and confirm each new doc renders with working language switcher and intra-doc anchors.
- [ ] From `README.md` and `README_en.md`, click each 📖 link under the 5 category headings and verify the target docs load.
- [ ] Spot-check the `u1-image-base` row in both READMEs: it now lists three tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)