### PR TITLE
docs: add "How to Use" section telling OpenClaw / Hermes users where to install skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ skills/
 | 智能体 | 目标目录 |
 |--------|---------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
-| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/openclaw-imports/` |
+| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/` |
 
-例如，把全部技能软链到 OpenClaw：
+例如，把全部技能复制到 OpenClaw：
 
 ```bash
 git clone https://github.com/OpenSenseNova/SenseNova-Skills.git
 mkdir -p ~/.openclaw/skills
-ln -s "$(pwd)/SenseNova-Skills/skills/"* ~/.openclaw/skills/
+cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
-Hermes 把目录换成 `~/.hermes/skills/openclaw-imports/` 即可。也可以只链需要的子目录（如 `u1-image-base`、`u1-infographic`）。OpenClaw 还支持通过 `openclaw.json` 的 `skills.load.extraDirs` 直接指向 `skills/`，详见下方各分类的 📖 详细使用指南。
+Hermes 把目录换成 `~/.hermes/skills/` 即可。
 
 各分类技能的 Python 依赖、API key 与调用示例同样请参考对应分类的 📖 详细使用指南。
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ skills/
 │   └── requirements.txt  # Python 依赖（可选）
 ```
 
+## 如何使用
+
+克隆本仓库后，把 `skills/` 下的子目录复制（或软链接）到所用智能体加载的 skills 目录：
+
+| 智能体 | 目标目录 |
+|--------|---------|
+| [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
+| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/openclaw-imports/` |
+
+例如，把全部技能软链到 OpenClaw：
+
+```bash
+git clone https://github.com/OpenSenseNova/SenseNova-Skills.git
+mkdir -p ~/.openclaw/skills
+ln -s "$(pwd)/SenseNova-Skills/skills/"* ~/.openclaw/skills/
+```
+
+Hermes 把目录换成 `~/.hermes/skills/openclaw-imports/` 即可。也可以只链需要的子目录（如 `u1-image-base`、`u1-infographic`）。OpenClaw 还支持通过 `openclaw.json` 的 `skills.load.extraDirs` 直接指向 `skills/`，详见下方各分类的 📖 详细使用指南。
+
+各分类技能的 Python 依赖、API key 与调用示例同样请参考对应分类的 📖 详细使用指南。
+
 ## 技能列表
 
 ### 🎨 图像与可视化

--- a/README_en.md
+++ b/README_en.md
@@ -38,22 +38,22 @@ skills/
 
 ## How to Use
 
-Clone this repository, then copy (or symlink) subdirectories under `skills/` into the skills directory your agent loads from:
+Clone this repository, then copy subdirectories under `skills/` into the skills directory your agent loads from:
 
 | Agent | Target directory |
 |-------|------------------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
-| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/openclaw-imports/` |
+| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/` |
 
-For example, symlink all skills into OpenClaw:
+For example, copy all skills into OpenClaw:
 
 ```bash
 git clone https://github.com/OpenSenseNova/SenseNova-Skills.git
 mkdir -p ~/.openclaw/skills
-ln -s "$(pwd)/SenseNova-Skills/skills/"* ~/.openclaw/skills/
+cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
-For Hermes, swap the target to `~/.hermes/skills/openclaw-imports/`. You can also link only the skills you need (e.g. `u1-image-base`, `u1-infographic`). OpenClaw additionally supports pointing `skills.load.extraDirs` in `openclaw.json` at the repo's `skills/` folder; see the 📖 Full guide under each category below.
+For Hermes, swap the target to `~/.hermes/skills/`.
 
 Per-category Python dependencies, API keys, and invocation examples are documented in the 📖 Full guide for each section.
 

--- a/README_en.md
+++ b/README_en.md
@@ -36,6 +36,27 @@ skills/
 │   └── requirements.txt  # Python deps (optional)
 ```
 
+## How to Use
+
+Clone this repository, then copy (or symlink) subdirectories under `skills/` into the skills directory your agent loads from:
+
+| Agent | Target directory |
+|-------|------------------|
+| [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
+| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/openclaw-imports/` |
+
+For example, symlink all skills into OpenClaw:
+
+```bash
+git clone https://github.com/OpenSenseNova/SenseNova-Skills.git
+mkdir -p ~/.openclaw/skills
+ln -s "$(pwd)/SenseNova-Skills/skills/"* ~/.openclaw/skills/
+```
+
+For Hermes, swap the target to `~/.hermes/skills/openclaw-imports/`. You can also link only the skills you need (e.g. `u1-image-base`, `u1-infographic`). OpenClaw additionally supports pointing `skills.load.extraDirs` in `openclaw.json` at the repo's `skills/` folder; see the 📖 Full guide under each category below.
+
+Per-category Python dependencies, API keys, and invocation examples are documented in the 📖 Full guide for each section.
+
 ## Skills List
 
 ### 🎨 Image & Visualization


### PR DESCRIPTION
## Summary
- Add a new \`## 如何使用\` / \`## How to Use\` section in `README.md` and `README_en.md`, slotted between `## 目录结构` / `## Directory Structure` and `## 技能列表` / `## Skills List`.
- The section tells users which directory their agent loads skills from, with a small comparison table:
  - OpenClaw → \`~/.openclaw/skills/\`
  - hermes-agent → \`~/.hermes/skills/openclaw-imports/\`
- Includes a one-liner symlink example for OpenClaw (Hermes users swap the target path).
- Points readers at the per-category 📖 docs under `docs/` for Python deps, API keys, and invocation samples — the README stays focused on the install step.

## Test plan
- [ ] Open the PR diff on GitHub and confirm the new section renders correctly above the skills table in both READMEs.
- [ ] Verify the OpenClaw and hermes-agent links resolve.
- [ ] Spot-check the bash example formatting (backticks survive markdown escaping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)