### PR TITLE
docs: fix hermes-agent link to nousresearch/hermes-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 简体中文 | [English](README_en.md)
 
-SenseNova系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes-agent](https://github.com/OpenSenseNova/hermes-agent) 等智能体，并借助skills实现更强大的能力。
+SenseNova系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes-agent](https://github.com/nousresearch/hermes-agent) 等智能体，并借助skills实现更强大的能力。
 
 本项目每个技能位于独立目录中，通过 `SKILL.md` 声明触发条件、能力边界和执行方式，遵循 [Agent Skills](https://agentskills.io/) 规范。
 
@@ -43,7 +43,7 @@ skills/
 | 智能体 | 目标目录 |
 |--------|---------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
-| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/` |
+| [hermes-agent](https://github.com/nousresearch/hermes-agent) | `~/.hermes/skills/` |
 
 例如，把全部技能复制到 OpenClaw：
 

--- a/README_en.md
+++ b/README_en.md
@@ -6,7 +6,7 @@
 
 English | [简体中文](README.md)
 
-The SenseNova model family plugs directly into agent runtimes such as [OpenClaw](https://openclaw.ai/) and [hermes-agent](https://github.com/OpenSenseNova/hermes-agent), and gains stronger capabilities through skills.
+The SenseNova model family plugs directly into agent runtimes such as [OpenClaw](https://openclaw.ai/) and [hermes-agent](https://github.com/nousresearch/hermes-agent), and gains stronger capabilities through skills.
 
 In this repository each skill lives in its own directory and declares triggers, capabilities, and execution flow through a `SKILL.md` file, following the [Agent Skills](https://agentskills.io/) convention.
 
@@ -43,7 +43,7 @@ Clone this repository, then copy subdirectories under `skills/` into the skills 
 | Agent | Target directory |
 |-------|------------------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
-| [hermes-agent](https://github.com/OpenSenseNova/hermes-agent) | `~/.hermes/skills/` |
+| [hermes-agent](https://github.com/nousresearch/hermes-agent) | `~/.hermes/skills/` |
 
 For example, copy all skills into OpenClaw:
 


### PR DESCRIPTION
## Summary
- Both `README.md` and `README_en.md` linked hermes-agent at `github.com/OpenSenseNova/hermes-agent`, which 404s.
- The repository actually lives at `github.com/nousresearch/hermes-agent`.
- Updated all 4 occurrences (intro paragraph + How-to-Use table, in both languages).

## Test plan
- [ ] Open the PR diff on GitHub and click each updated hermes-agent link to confirm it resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)