### PR TITLE
docs(readme): rewrite Sample Outputs example summaries from agent's perspective

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,25 +113,25 @@ A few `sn-infographic` outputs (more in [`docs/sn-infographic-examples.md`](docs
 
 ### 🧩 Memory price analysis — end-to-end pipeline
 
-[`examples/memory-price-end2end-analysis`](examples/memory-price-end2end-analysis/) — end-to-end example: chains data analysis → deep research → PPT generation. Starting from a price CSV, it produces a Markdown / HTML data analysis report, an illustrated deep research report, and a 16-page PPTX.
+[`examples/memory-price-end2end-analysis`](examples/memory-price-end2end-analysis/). Starting from a raw quote CSV, the agent profiles fields, normalizes categories and timestamps, then attacks the rally from three angles — overall trend, top movers per category, and the gap between server-grade and consumer-grade SKUs — locating a late-February inflection along the way. Treating those findings as the research question, it switches to deep research: planning per-dimension web searches over supply contraction, AI-server demand, and vendor output discipline, then triaging and cross-checking evidence across sources before committing it to the report. The data and research conclusions are then handed to PPT generation, which lays out a 16-page outline, plans per-slot imagery, renders per-page HTML, runs VLM review, and finally composites screenshots into the PPTX. The result is a clear three-step storyline: prices *are* rising → *here is why* → *here is what to do*. This is the only example that exercises the full data analysis → deep research → PPT chain end-to-end.
 
 - Depends on: [`sn-da-excel-workflow`](skills/sn-da-excel-workflow/SKILL.md), [`sn-deep-research`](skills/sn-deep-research/SKILL.md), [`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md), [`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md), [`sn-md-to-html-report`](skills/sn-md-to-html-report/SKILL.md)
 
 ### 📊 Employee performance analysis — single-skill case (data analysis)
 
-[`examples/employee-performance-analysis`](examples/employee-performance-analysis/) — distills 10 monthly performance review spreadsheets into a Word-format performance report plus a visualized HTML report with 8 figures.
+[`examples/employee-performance-analysis`](examples/employee-performance-analysis/). The agent reads 10 separate monthly review xlsx files, aligns column schemas across months and joins them into one longitudinal table. From that table it produces aggregate views — monthly average trend, score-distribution boxplots, grade mix change, and a 38-role ranking — and individual views — top performers, needs-attention, and consistently-improving cohorts plus per-employee year trends. The findings are written up with explicit improvement suggestions tied to specific roles and individuals, backed by 8 supporting charts. The same content is delivered as a Word doc (for distribution) and a visualized HTML report (for browsing). The example shows how `sn-da-excel-workflow` handles "many small spreadsheets that should be one analysis" rather than a single big file.
 
 - Depends on: [`sn-da-excel-workflow`](skills/sn-da-excel-workflow/SKILL.md)
 
 ### 🔬 Embodied AI industry research — single-skill case (deep research)
 
-[`examples/embodied-ai-deep-research`](examples/embodied-ai-deep-research/) — built from a single prompt with no input file: an industry research report with 5 figures (market size, share, financing, cost structure, roadmap).
+[`examples/embodied-ai-deep-research`](examples/embodied-ai-deep-research/). Given only an industry name, the agent first commits to a research plan — market size, vendor share, financing, cost structure, development roadmap — instead of jumping straight into search. For each dimension it runs targeted web searches, fetches and reads source pages, and extracts both numeric and qualitative evidence; conflicting figures across sources are explicitly reconciled before being trusted. A synthesis stage stitches the per-dimension evidence into a coherent industry narrative rather than a stack of disconnected bullets. The output is an illustrated report (Markdown + visualized HTML) with 5 dimension-specific charts. The example shows how `sn-deep-research` turns "go research X" into a structured plan-then-execute loop with traceable evidence.
 
 - Depends on: [`sn-deep-research`](skills/sn-deep-research/SKILL.md)
 
 ### 🎯 Property fee pricing PPT — single-skill case (PPT generation)
 
-[`examples/property-fee-pricing-ppt`](examples/property-fee-pricing-ppt/) — a 26-page PPTX in a black-and-white warm style, plus the per-page HTML sources, generated from a single prompt.
+[`examples/property-fee-pricing-ppt`](examples/property-fee-pricing-ppt/). The agent takes a free-form brief — topic (property fee pricing), audience (property staff + committee), 26 pages, black-and-white warm style — and first commits to an outline plus a per-page asset plan that conforms to the style spec. Each slide is then built as semantic per-page HTML rather than free-form image generation: copy, layout, illustrations, icons, and any data charts are reasoned about per slot. Imagery is produced or selected per slot and VLM-checked against the page's intent; each rendered page goes through a review pass with optional rewrite for coherence and copy quality. Final pages are screenshotted and composited into the PPTX, with the per-page HTML kept alongside for direct browser preview or re-editing. The example demonstrates `sn-ppt-standard` style consistency on a long, prose-heavy deck where every slide must obey the same audience and palette constraints.
 
 - Depends on: [`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md), [`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,25 +113,25 @@ Hermes 把目录换成 `~/.hermes/skills/` 即可。
 
 ### 🧩 内存价格分析 — 端到端流水线
 
-[`examples/memory-price-end2end-analysis`](examples/memory-price-end2end-analysis/) — 端到端样例：串联 数据分析 → 深度调研 → PPT 生成。从一份价格 CSV 出发，产出数据分析 Markdown / HTML 报告、图文深度调研报告，以及 16 页 PPTX。
+[`examples/memory-price-end2end-analysis`](examples/memory-price-end2end-analysis/)。智能体先对原始报价 CSV 做字段刻画、品类与时间戳标准化，然后从「整体走势」「分品类涨幅 Top」「服务器级 vs 消费级背离」三个角度刻画本轮上涨，沿途定位 2 月下旬的拐点。把数据结论作为新的研究问题，转入深度调研：按维度规划检索（供给收缩、AI 服务器需求、原厂控产），并在不同来源之间交叉验证证据后再写入报告。数据 + 研究结论一并交给 PPT 生成：先排 16 页大纲、规划每页素材，再生成分页 HTML、做 VLM 评审、最后把分页截图合成 PPTX。最终是一条清晰的三段叙事：价格在涨 → 为什么涨 → 怎么应对。这是仓库里唯一一个完整跑过 数据分析 → 深度调研 → PPT 的端到端样例。
 
 - 依赖技能：[`sn-da-excel-workflow`](skills/sn-da-excel-workflow/SKILL.md)、[`sn-deep-research`](skills/sn-deep-research/SKILL.md)、[`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md)、[`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)、[`sn-md-to-html-report`](skills/sn-md-to-html-report/SKILL.md)
 
 ### 📊 员工绩效分析 — 独立样例（数据分析）
 
-[`examples/employee-performance-analysis`](examples/employee-performance-analysis/) — 从 10 份月度绩效考核表汇总出 Word 版绩效报告，并补一份含 8 张图表的可视化 HTML 报告。
+[`examples/employee-performance-analysis`](examples/employee-performance-analysis/)。智能体先把 10 份分散的月度考核 xlsx 读入，对齐各月列结构，纵向拼成一张长表。在这张表上分别做总体视角（月度均值趋势、得分分布箱线图、等级占比变化、38 个岗位排名）和个体视角（优秀 / 待提升 / 持续进步三类员工，配合个人年度走势）的分析。结论部分把改进建议落到具体岗位和具体员工，并用 8 张图表佐证。同样的内容产出 Word 版（适合下发）和可视化 HTML 版（适合浏览）两种形态。这个样例展示了 `sn-da-excel-workflow` 如何把「一堆零散的小表」当成一次完整分析来处理。
 
 - 依赖技能：[`sn-da-excel-workflow`](skills/sn-da-excel-workflow/SKILL.md)
 
 ### 🔬 具身智能行业调研 — 独立样例（深度调研）
 
-[`examples/embodied-ai-deep-research`](examples/embodied-ai-deep-research/) — 仅凭一句 prompt、无任何输入文件，产出行业调研报告，含 5 张图表（市场规模、份额、融资、成本、路线图）。
+[`examples/embodied-ai-deep-research`](examples/embodied-ai-deep-research/)。给定一个行业关键词后，智能体先列出研究维度（市场规模、玩家份额、融资、成本结构、发展路线），而不是直接撒网搜索。每个维度按计划做定向检索、抓取并阅读原始页面，提取数值与定性证据；不同来源之间出现冲突的数字会先做 reconcile 再落到报告里。综合阶段把各维度证据串成一条连贯的行业叙事，而不是一堆互不连接的要点。最终产出是一份图文并茂的报告（Markdown + 可视化 HTML），含 5 张分维度的配图。这个样例展示了 `sn-deep-research` 如何把一句「调研 X」变成「先规划再执行、证据可追溯」的结构化闭环。
 
 - 依赖技能：[`sn-deep-research`](skills/sn-deep-research/SKILL.md)
 
 ### 🎯 物业费定价体系 PPT — 独立样例（PPT 生成）
 
-[`examples/property-fee-pricing-ppt`](examples/property-fee-pricing-ppt/) — 仅凭一句 prompt 产出的 26 页黑白温馨风 PPTX，附分页 HTML 源。
+[`examples/property-fee-pricing-ppt`](examples/property-fee-pricing-ppt/)。智能体读到一份开放式输入（主题：物业费定价；受众：物业管理人员 + 物业委员会；26 页；黑白温馨风），先确定大纲，再产出符合风格规范的逐页素材计划。每一页以语义化的 HTML 方式构造，而不是直接出整页大图：文案、版式、配图、图标、需要的数据图表都是分槽位规划的。素材按槽位生成或选型，并由 VLM 对照页面意图做质检；每页 HTML 渲染出来后再走一轮评审与按需改写，保证用语和视觉一致性。最后把分页截图合成 PPTX，分页 HTML 也保留下来，便于直接在浏览器里预览或继续修改。这个样例展示了 `sn-ppt-standard` 在一份偏文本、长篇幅的方案稿上如何在每一页都遵守同一套受众和配色约束。
 
 - 依赖技能：[`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md)、[`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)
 


### PR DESCRIPTION
## Summary

Rewrite the four example summaries in `README.md` / `README_CN.md` Sample Outputs section so each one describes how the agent actually approaches the task — what angle of analysis, what methods are used, and what each step produces — instead of a one-liner about the inputs/outputs. Roughly 5 sentences per example, mirrored between English and Chinese.

Affected entries:
- 🧩 Memory price analysis (end-to-end pipeline)
- 📊 Employee performance analysis (single-skill — data analysis)
- 🔬 Embodied AI industry research (single-skill — deep research)
- 🎯 Property fee pricing PPT (single-skill — PPT generation)

No code changes; no example artifacts touched.

## Test plan

- [ ] Render `README.md` and `README_CN.md` on GitHub and confirm the four entries read naturally and match each other's structure
- [ ] Confirm the heading structure is unchanged (still ### at the same level as 🎨 Infographic) and the "Depends on / 依赖技能" lines still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)