### PR TITLE
docs: fix broken links, stale commands, and CN/EN drift across docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -303,5 +303,5 @@ If the agent enumerates skills like `sn-infographic`, `sn-ppt-entry`, and `sn-de
 - **`wsl --install` not found**: needs Windows 10 22H2+ / Windows 11, run PowerShell as Administrator.
 - **Node version too low**: `node -v` must be ≥ 22.14. Switch with nvm: `nvm install 24 && nvm use 24`.
 - **`openclaw doctor` / `hermes doctor` complains**: follow the report's hints — install whatever's missing.
-- **LLM returns 401 / 403**: double-check `OPENAI_API_KEY` or the key in the config file; confirm your key still has free quota in [token-plan](https://platform.sensenova.cn/token-plan).
+- **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); confirm the key still has free quota in [token-plan](https://platform.sensenova.cn/token-plan).
 - **Slow `curl` inside WSL2**: check the WSL2 networking mode (`wsl --status`); switch to `mirrored` networking or use a proxy if needed.

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -303,5 +303,5 @@ cp -r skills/* ~/.hermes/skills/
 - **`wsl --install` 提示找不到命令**：需要 Windows 10 22H2+ / Windows 11，并以管理员身份打开 PowerShell。
 - **Node 版本太低**：`node -v` 必须 ≥ 22.14。用 nvm 切换：`nvm install 24 && nvm use 24`。
 - **`openclaw doctor` / `hermes doctor` 报错**：按报告中的提示逐项修复，缺什么装什么。
-- **LLM 调用 401 / 403**：检查 `OPENAI_API_KEY` 或配置文件中的 key 是否填错；确认 [token-plan](https://platform.sensenova.cn/token-plan) 中 key 仍在有效额度内。
+- **LLM 调用 401 / 403**：检查配置中的 LLM API Key（OpenClaw 用 `openclaw config get models.providers.custom`，hermes-agent 用 `hermes config get model.api_key`）；确认 [token-plan](https://platform.sensenova.cn/token-plan) 中 key 仍在有效额度内。
 - **WSL2 中 `curl` 慢/卡**：确认 WSL2 网络模式（`wsl --status`），必要时切到 `mirrored` 网络模式或使用代理。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 English | [简体中文](README_CN.md)
 
-The SenseNova model family plugs directly into agent runtimes such as [OpenClaw](https://openclaw.ai/) and [hermes-agent](https://github.com/nousresearch/hermes-agent), and gains stronger capabilities through skills.
+The SenseNova model family plugs directly into agent runtimes such as [OpenClaw](https://openclaw.ai/) and [hermes-agent](https://github.com/NousResearch/hermes-agent), with the skills in this repository extending the models with concrete, end-to-end office capabilities.
 
 In this repository each skill lives in its own directory and declares triggers, capabilities, and execution flow through a `SKILL.md` file, following the [Agent Skills](https://agentskills.io/) convention.
 
@@ -21,7 +21,7 @@ Clone this repository, then copy subdirectories under `skills/` into the skills 
 | Agent | Target directory |
 |-------|------------------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
-| [hermes-agent](https://github.com/nousresearch/hermes-agent) | `~/.hermes/skills/` |
+| [hermes-agent](https://github.com/NousResearch/hermes-agent) | `~/.hermes/skills/` |
 
 For example, copy all skills into OpenClaw:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,7 +6,7 @@
 
 简体中文 | [English](README.md)
 
-SenseNova系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes-agent](https://github.com/nousresearch/hermes-agent) 等智能体，并借助skills实现更强大的能力。
+SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes-agent](https://github.com/NousResearch/hermes-agent) 等智能体；本仓库的 skills 则把这些模型扩展为可直接落地的端到端办公能力。
 
 本项目每个技能位于独立目录中，通过 `SKILL.md` 声明触发条件、能力边界和执行方式，遵循 [Agent Skills](https://agentskills.io/) 规范。
 
@@ -21,7 +21,7 @@ SenseNova系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes-
 | 智能体 | 目标目录 |
 |--------|---------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
-| [hermes-agent](https://github.com/nousresearch/hermes-agent) | `~/.hermes/skills/` |
+| [hermes-agent](https://github.com/NousResearch/hermes-agent) | `~/.hermes/skills/` |
 
 例如，把全部技能复制到 OpenClaw：
 

--- a/docs/deep-research.md
+++ b/docs/deep-research.md
@@ -28,7 +28,7 @@
 | 名称 | 角色 | 说明 |
 |------|------|------|
 | [`sn-search-academic`](../skills/sn-search-academic/SKILL.md) | 学术搜索 | ArXiv（含 HTML 全文按章节读）/ Semantic Scholar（含引用数与正反向引用链）/ PubMed（含 PMC 开放获取全文）/ Wikipedia 多语言聚合。 |
-| [`sn-search-code`](../skills/sn-search-code/SKILL.md) | 开发者搜索 | GitHub（仓库 / 代码 / Issue）/ Stack Overflow（按标签 / 票数）/ HuggingFace（模型 / 数据集 / Space）/ Hacker News 四平台聚合。 |
+| [`sn-search-code`](../skills/sn-search-code/SKILL.md) | 开发者搜索 | GitHub（仓库 / 代码 / Issue）/ Stack Overflow（按标签 / 票数）/ Hacker News / HuggingFace（模型 / 数据集 / Space）四平台聚合。 |
 | [`sn-search-social-cn`](../skills/sn-search-social-cn/SKILL.md) | 中文社交搜索 | B 站 / 知乎 / 抖音 三个中文社交平台搜索；知乎、抖音必须配 cookie，B 站 cookie 可选。 |
 | [`sn-search-social-en`](../skills/sn-search-social-en/SKILL.md) | 英文社交搜索 | Reddit（按 subreddit / 排序 / 时间）/ Twitter (X)（经 TikHub）/ YouTube（API key）。 |
 
@@ -122,7 +122,7 @@ ZHIHU_COOKIE="..." python3 skills/sn-search-social-cn/scripts/zhihu_search.py "P
 - `synthesis.md` —— 综合判断（主线、共识、冲突、不确定性）
 - `report.md` —— 最终报告
 
-更多样例参见 [`docs/sn-deep-research-examples.md`](sn-deep-research-examples.md)（待补充）。
+_更多端到端样例参见仓库根目录 [`README_CN.md`](../README_CN.md#输出样例) 中的「输出样例」章节。_
 
 ### 搜索
 

--- a/docs/deep-research_en.md
+++ b/docs/deep-research_en.md
@@ -28,7 +28,7 @@ Deep-research skills handle planning, synthesis, and final writing. Search skill
 | Name | Role | Description |
 |------|------|-------------|
 | [`sn-search-academic`](../skills/sn-search-academic/SKILL.md) | Academic search | ArXiv (with section-by-section HTML full-text reading) / Semantic Scholar (citation counts and forward/backward citation chains) / PubMed (with PMC open-access full text) / Wikipedia (multi-language). |
-| [`sn-search-code`](../skills/sn-search-code/SKILL.md) | Developer search | GitHub (repos / code / issues) / Stack Overflow (by tag / votes) / HuggingFace (models / datasets / Spaces) / Hacker News. |
+| [`sn-search-code`](../skills/sn-search-code/SKILL.md) | Developer search | GitHub (repos / code / issues) / Stack Overflow (by tag / votes) / Hacker News / HuggingFace (models / datasets / Spaces). |
 | [`sn-search-social-cn`](../skills/sn-search-social-cn/SKILL.md) | Chinese social search | Bilibili / Zhihu / Douyin; Zhihu and Douyin require cookies, Bilibili cookie is optional. |
 | [`sn-search-social-en`](../skills/sn-search-social-en/SKILL.md) | English social search | Reddit (subreddit / sort / time range) / Twitter (X) (via TikHub) / YouTube (API key). |
 
@@ -122,7 +122,7 @@ Report artifacts are written to `{workspace}/reports/{YYYY-MM-DD}-{slug}-{hex4}/
 - `synthesis.md` — synthesis (main lines, consensus, conflicts, uncertainty)
 - `report.md` — final report
 
-More samples: [`docs/sn-deep-research-examples.md`](sn-deep-research-examples.md) (TBD).
+_See the "Sample Outputs" section in the top-level [`README.md`](../README.md#sample-outputs) for end-to-end examples._
 
 ### Search
 

--- a/docs/ppt-generate.md
+++ b/docs/ppt-generate.md
@@ -19,7 +19,7 @@
 | [`sn-ppt-creative`](../skills/sn-ppt-creative/SKILL.md) | PPT 创意模式 | 每页一张 16:9 全图（PNG），按页面构图 prompt 走 `sn-image-generate` 一次性出图后导出 PPTX。 |
 | [`sn-ppt-standard`](../skills/sn-ppt-standard/SKILL.md) | PPT 标准模式 | `style_spec` → 大纲 → 资产规划 + 分槽位图像 + VLM 质检 → 分页 HTML → 分页评审（可选重写）→ 汇总 `review.md` → 导出 PPTX。 |
 
-`sn-ppt-creative` 依赖 `sn-image-base` 进行文生图；`sn-ppt-standard` 自带模型调用脚本（`scripts/run_stage.py`）。
+`sn-ppt-creative` 依赖 `sn-image-base` 进行文生图；`sn-ppt-standard` 自带 LLM / VLM 调用脚本（`scripts/run_stage.py`），文生图阶段仍走 `sn-image-base`。
 
 ## Quick Start
 
@@ -74,9 +74,9 @@ SN_API_KEY="your-api-key"
 PPT 产物默认保存在 `$(pwd)/ppt_decks/<topic>_<timestamp>/`，目录内包含：
 
 - `task_pack.json` / `info_pack.json` —— `sn-ppt-entry` 解析后的任务参数
-- `style_spec.md`、`outline.json` —— 风格与大纲（标准模式）
+- `style_spec.json`（标准模式）/ `style_spec.md`（创意模式）、`outline.json` —— 风格与大纲
 - `pages/page_*.png` —— 单页全图（创意模式）或 HTML 渲染图（标准模式）
 - `review.md` —— 分页评审汇总（标准模式）
 - `<deck_id>.pptx` —— 最终 PPTX
 
-更多样例参见 [`docs/ppt-examples.md`](ppt-examples.md)（待补充）。
+_更多端到端样例参见仓库根目录 [`README_CN.md`](../README_CN.md#输出样例) 中的「输出样例」章节。_

--- a/docs/ppt-generate_en.md
+++ b/docs/ppt-generate_en.md
@@ -19,7 +19,7 @@ This document collects the PPT generation skills (`sn-ppt-entry`, `sn-ppt-doctor
 | [`sn-ppt-creative`](../skills/sn-ppt-creative/SKILL.md) | PPT creative mode | One full-page 16:9 PNG per slide, generated via `sn-image-generate` from a per-page composed prompt; exports PPTX. |
 | [`sn-ppt-standard`](../skills/sn-ppt-standard/SKILL.md) | PPT standard mode | `style_spec` → outline → asset plan + per-slot images + VLM QA → per-page HTML → per-page review (optional rewrite) → summary `review.md` → PPTX export. |
 
-`sn-ppt-creative` depends on `sn-image-base` for text-to-image; `sn-ppt-standard` ships its own model invocation scripts (`scripts/run_stage.py`).
+`sn-ppt-creative` depends on `sn-image-base` for text-to-image; `sn-ppt-standard` ships its own LLM / VLM invocation scripts (`scripts/run_stage.py`) but still routes text-to-image through `sn-image-base`.
 
 ## Quick Start
 
@@ -74,9 +74,9 @@ Or call by name:
 Decks are written to `$(pwd)/ppt_decks/<topic>_<timestamp>/`, containing:
 
 - `task_pack.json` / `info_pack.json` — parsed task parameters from `sn-ppt-entry`
-- `style_spec.md`, `outline.json` — style and outline (standard mode)
+- `style_spec.json` (standard mode) / `style_spec.md` (creative mode), `outline.json` — style and outline
 - `pages/page_*.png` — full-page images (creative) or HTML-rendered slides (standard)
 - `review.md` — per-page review summary (standard mode)
 - `<deck_id>.pptx` — final PPTX
 
-More samples: [`docs/ppt-examples.md`](ppt-examples.md) (TBD).
+_See the "Sample Outputs" section in the top-level [`README.md`](../README.md#sample-outputs) for end-to-end examples._

--- a/skills/sn-deep-research/SKILL.md
+++ b/skills/sn-deep-research/SKILL.md
@@ -24,8 +24,9 @@ description: 深度调研编排器，覆盖 规划→分维度取证→综合→
 sn-deep-research 需要 OpenClaw web_search 可用，但当前未确认 web_search 可用。
 
 请先任选一种方式配置：
-1. 按所选 provider 设置环境变量；Gateway 安装可写入 `~/.openclaw/.env`
-2. 或用 `openclaw config set tools.web.search.provider <provider>` 等命令直接写入 OpenClaw 配置（含 `plugins.entries.<plugin>.config.webSearch.*` 下的相关字段）
+1. 运行 `openclaw configure --section web`
+2. 或按所选 provider 设置环境变量；Gateway 安装可写入 `~/.openclaw/.env`
+3. 或在 OpenClaw 配置中写入 `plugins.entries.<plugin>.config.webSearch.*`
 
 配置后重启或刷新 OpenClaw 会话，再重新发起 sn-deep-research。
 ```

--- a/skills/sn-deep-research/SKILL.md
+++ b/skills/sn-deep-research/SKILL.md
@@ -24,9 +24,8 @@ description: 深度调研编排器，覆盖 规划→分维度取证→综合→
 sn-deep-research 需要 OpenClaw web_search 可用，但当前未确认 web_search 可用。
 
 请先任选一种方式配置：
-1. 运行 `openclaw configure --section web`
-2. 或按所选 provider 设置环境变量；Gateway 安装可写入 `~/.openclaw/.env`
-3. 或在 OpenClaw 配置中写入 `plugins.entries.<plugin>.config.webSearch.*`
+1. 按所选 provider 设置环境变量；Gateway 安装可写入 `~/.openclaw/.env`
+2. 或用 `openclaw config set tools.web.search.provider <provider>` 等命令直接写入 OpenClaw 配置（含 `plugins.entries.<plugin>.config.webSearch.*` 下的相关字段）
 
 配置后重启或刷新 OpenClaw 会话，再重新发起 sn-deep-research。
 ```


### PR DESCRIPTION
## Summary

Audit pass over all top-level docs (READMEs, INSTALL, `docs/*`). Fixes broken links, stale commands, and CN/EN drift. **No content/feature additions** — all edits are corrections to existing prose.

- Drop dead links to `docs/ppt-examples.md` and `docs/sn-deep-research-examples.md` (TBD files that were never created); redirect readers to the existing "Sample Outputs" section in the README instead.
- Fix standard-mode artifact extension in `docs/ppt-generate{,_en}.md`: `style_spec.json` (standard) / `style_spec.md` (creative). The scripts under `sn-ppt-standard/scripts/run_stage.py` always write `.json`, so the doc was misleading users.
- Replace misleading `OPENAI_API_KEY` mention in `INSTALL{,_CN}.md` 401/403 troubleshooting with the actual config-key locations (`openclaw config get models.providers.custom` / `hermes config get model.api_key`) — the install steps never set `OPENAI_API_KEY`.
- Standardize the hermes-agent GitHub URL on `NousResearch` casing in both READMEs (was inconsistently lowercase in two spots).
- Align `sn-search-code` source ordering in deep-research docs with the README and the skill's own SKILL.md (GitHub / SO / HN / HuggingFace).
- Note that `sn-ppt-standard` ships its own LLM/VLM scripts but still routes text-to-image through `sn-image-base` (was previously implied to be self-contained).
- Tighten the circular opening sentence in both READMEs.

> Note: an earlier commit on this branch also tweaked `skills/sn-deep-research/SKILL.md`, but it has been reverted — this PR no longer touches anything under `skills/`.

## Test plan

- [x] All edited Markdown files render in GitHub preview (no syntax breakage).
- [x] No remaining references to `OPENAI_API_KEY`, lowercase `nousresearch`, `ppt-examples.md`, or `sn-deep-research-examples.md` (confirmed via grep).
- [x] `style_spec.md` mentions outside `sn-ppt-creative/` only appear where both modes are explicitly distinguished.
- [x] Final scope: 8 doc files only; `skills/` directory untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)