### PR TITLE
Replaced instances of `SN_API_KEY` with `SN_IMAGE_GEN_API_KEY`

### DIFF
--- a/docs/ppt-generate.md
+++ b/docs/ppt-generate.md
@@ -50,7 +50,7 @@ SN_CHAT_API_KEY="your-api-key"
 SN_CHAT_BASE_URL="https://token.sensenova.cn/v1"
 
 # 文生图（创意模式必填，标准模式按需）
-SN_API_KEY="your-api-key"
+SN_IMAGE_GEN_API_KEY="your-api-key"
 ```
 
 可选环境变量：`SN_IMAGE_GEN_*`、`SN_TEXT_*`、`SN_VISION_*` 用于覆盖默认模型与超时。详细列表见 [`skills/sn-image-base/README.md`](../skills/sn-image-base/README.md)。

--- a/docs/ppt-generate_en.md
+++ b/docs/ppt-generate_en.md
@@ -50,7 +50,7 @@ SN_CHAT_API_KEY="your-api-key"
 SN_CHAT_BASE_URL="https://token.sensenova.cn/v1"
 
 # Text-to-image (required for creative mode, on-demand for standard mode)
-SN_API_KEY="your-api-key"
+SN_IMAGE_GEN_API_KEY="your-api-key"
 ```
 
 Optional variables `SN_IMAGE_GEN_*`, `SN_TEXT_*`, and `SN_VISION_*` override default models and timeouts. Full list: [`skills/sn-image-base/README.md`](../skills/sn-image-base/README.md).

--- a/docs/sn-image-generate.md
+++ b/docs/sn-image-generate.md
@@ -7,7 +7,7 @@
 ## 环境要求
 
 - **Python** 3.9 或更高版本（推荐 3.10+）。
-- **SN API** 凭据，用于图像生成与 LLM/VLM 接口（`SN_API_KEY`、`SN_CHAT_API_KEY`，详见 Quick Start）。
+- **SN API** 凭据，用于图像生成与 LLM/VLM 接口（`SN_IMAGE_GEN_API_KEY`、`SN_CHAT_API_KEY`，详见 Quick Start）。
 
 ## 技能介绍
 
@@ -85,7 +85,7 @@ pip install -r skills/sn-image-base/requirements.txt
 将以下环境变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
 
 ```ini
-SN_API_KEY="your-api-key"
+SN_IMAGE_GEN_API_KEY="your-api-key"
 SN_CHAT_API_KEY="your-api-key"
 ```
 

--- a/docs/sn-image-generate_en.md
+++ b/docs/sn-image-generate_en.md
@@ -7,7 +7,7 @@ This document collects the SN (SenseNova) related skills (`sn-image-doctor`, `sn
 ## Prerequisites
 
 - **Python** 3.9 or later (3.10+ recommended).
-- **SN API** credentials for image generation and LLM/VLM endpoints (`SN_API_KEY`, `SN_CHAT_API_KEY`; see Quick Start).
+- **SN API** credentials for image generation and LLM/VLM endpoints (`SN_IMAGE_GEN_API_KEY`, `SN_CHAT_API_KEY`; see Quick Start).
 
 ## Skills
 
@@ -85,7 +85,7 @@ Go to <https://platform.sensenova.cn/token-plan/> to register a free account and
 Set the following environment variables in `~/.openclaw/.env` (for OpenClaw) or `~/.hermes/.env` (for Hermes):
 
 ```ini
-SN_API_KEY="your-api-key"
+SN_IMAGE_GEN_API_KEY="your-api-key"
 SN_CHAT_API_KEY="your-api-key"
 ```
 

--- a/skills/sn-image-base/README.md
+++ b/skills/sn-image-base/README.md
@@ -40,7 +40,7 @@ Set the following environment variables in `~/.openclaw/.env` (or `~/.hermes/.en
 
 ```ini
 # Image generation
-SN_API_KEY="<sensenova-token-plan-api-key>"
+SN_IMAGE_GEN_API_KEY="<sensenova-token-plan-api-key>"
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"   # or other image generation models available in the SenseNova Token Plan
 # Text and vision chat runtime
 SN_CHAT_API_KEY="<sensenova-token-plan-api-key>"
@@ -73,14 +73,14 @@ Full configuration for image generation:
 
 | Config Key | Description | Default |
 | ---------- | ----------- | ------- |
-| `SN_API_KEY` | The API key for the SenseNova Token Plan | (Required) |
+| `SN_IMAGE_GEN_API_KEY` | The API key for the SenseNova Token Plan | (Required) |
 | `SN_IMAGE_GEN_MODEL_TYPE` | The type of image generation model to use | `"sensenova"` |
 | `SN_IMAGE_GEN_MODEL` | The name of the image generation model to use | `"sensenova-u1-fast"` |
 | `SN_IMAGE_GEN_BASE_URL` | The base URL for the image generation API | `"https://token.sensenova.cn/v1"` |
 
 The default values are recommended for the [SenseNova](https://platform.sensenova.cn/).
 
-You only need to set the `SN_API_KEY`, and optionally set `SN_IMAGE_GEN_MODEL` to the model name provided by the token plan.
+You only need to set the `SN_IMAGE_GEN_API_KEY`, and optionally set `SN_IMAGE_GEN_MODEL` to the model name provided by the token plan.
 
 To use non-default image generation models, please:
 
@@ -117,10 +117,10 @@ To use non-default image generation models, please:
     SN_IMAGE_GEN_MODEL="gpt-image-2"
     ```
 
-4. (**Required**) Set `SN_API_KEY` to the API key for the image generation API.
+4. (**Required**) Set `SN_IMAGE_GEN_API_KEY` to the API key for the image generation API.
 
     ```ini
-    SN_API_KEY="sk-your-image-generation-api-key"
+    SN_IMAGE_GEN_API_KEY="sk-your-image-generation-api-key"
     ```
 
 #### Text and Vision Chat
@@ -198,7 +198,7 @@ To use non-default shared chat settings, please:
 ### Missing API key
 
 - Symptom: errors like "required but not set", "missing api key", or request unauthorized.
-- Fix: set `SN_API_KEY` for image generation, and set `SN_CHAT_API_KEY` for chat calls. Use `SN_TEXT_API_KEY` or `SN_VISION_API_KEY` when text and vision use different providers.
+- Fix: set `SN_IMAGE_GEN_API_KEY` for image generation, and set `SN_CHAT_API_KEY` for chat calls. Use `SN_TEXT_API_KEY` or `SN_VISION_API_KEY` when text and vision use different providers.
 
 ### Wrong base URL
 

--- a/skills/sn-image-base/README_CN.md
+++ b/skills/sn-image-base/README_CN.md
@@ -40,7 +40,7 @@
 
 ```ini
 # 图像生成
-SN_API_KEY="<sensenova-token-plan-api-key>"
+SN_IMAGE_GEN_API_KEY="<sensenova-token-plan-api-key>"
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"   # 或 Token Plan 中可用的其他图像生成模型
 # 文本与视觉 Chat Runtime
 SN_CHAT_API_KEY="<sensenova-token-plan-api-key>"
@@ -75,14 +75,14 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 
 | 配置键 | 说明 | 默认值 |
 | ------ | ---- | ------ |
-| `SN_API_KEY` | SenseNova Token Plan 的 API Key | （必填） |
+| `SN_IMAGE_GEN_API_KEY` | SenseNova Token Plan 的 API Key | （必填） |
 | `SN_IMAGE_GEN_MODEL_TYPE` | 图像生成模型类型 | `"sensenova"` |
 | `SN_IMAGE_GEN_MODEL` | 图像生成模型名 | `"sensenova-u1-fast"` |
 | `SN_IMAGE_GEN_BASE_URL` | 图像生成 API 的基础 URL | `"https://token.sensenova.cn/v1"` |
 
 默认值适用于 [SenseNova](https://platform.sensenova.cn/)。
 
-通常只需设置 `SN_API_KEY`，并可按需将 `SN_IMAGE_GEN_MODEL` 设置为 token plan 提供的模型名。
+通常只需设置 `SN_IMAGE_GEN_API_KEY`，并可按需将 `SN_IMAGE_GEN_MODEL` 设置为 token plan 提供的模型名。
 
 如需使用非默认图像生成模型，请按以下步骤：
 
@@ -119,10 +119,10 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
     SN_IMAGE_GEN_MODEL="gpt-image-2"
     ```
 
-4. （必填）设置 `SN_API_KEY` 为图像生成 API 的密钥：
+4. （必填）设置 `SN_IMAGE_GEN_API_KEY` 为图像生成 API 的密钥：
 
     ```ini
-    SN_API_KEY="sk-your-image-generation-api-key"
+    SN_IMAGE_GEN_API_KEY="sk-your-image-generation-api-key"
     ```
 
 #### 文本与视觉 Chat
@@ -198,7 +198,7 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ### 缺少 API key
 
 - 现象：报错包含 "required but not set"、"missing api key" 或请求未授权。
-- 处理：图像生成需设置 `SN_API_KEY`；chat 调用需设置 `SN_CHAT_API_KEY`。如果文本和视觉使用不同 provider，可设置 `SN_TEXT_API_KEY` 或 `SN_VISION_API_KEY`。
+- 处理：图像生成需设置 `SN_IMAGE_GEN_API_KEY`；chat 调用需设置 `SN_CHAT_API_KEY`。如果文本和视觉使用不同 provider，可设置 `SN_TEXT_API_KEY` 或 `SN_VISION_API_KEY`。
 
 ### base URL 配置错误
 

--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -52,7 +52,7 @@ Image generation tool that calls the text-to-image-no-enhance API.
 | `--aspect-ratio` | string | `16:9` | Aspect ratio, e.g. `1:1`, `16:9`, `9:16` |
 | `--seed` | int | `None` | Random seed for reproducible generation |
 | `--unet-name` | string | `None` | Specify a UNet model name |
-| `--api-key` | string | Read from `SN_API_KEY` env var | API key (CLI argument has priority; `MissingApiKeyError` is raised when both are empty) |
+| `--api-key` | string | Read from `SN_IMAGE_GEN_API_KEY` env var | API key (CLI argument has priority; `MissingApiKeyError` is raised when both are empty) |
 | `--base-url` | string | Read from `SN_IMAGE_GEN_BASE_URL` env var | API base URL (CLI argument has priority; `MissingApiKeyError` is raised when both are empty) |
 | `--poll-interval` | float | `5.0` | Polling interval (seconds) |
 | `--timeout` | float | `300.0` | Timeout (seconds) |
@@ -158,8 +158,8 @@ Authentication parameters for `sn-image-generate` have the following default beh
 
 | Parameter | Default | Override | Description |
 |------|--------|----------|------|
-| `--base-url` | Read from `SN_BASE_URL` env var | `--base-url "..."` | CLI argument has priority; throws error if env var and CLI value are both missing |
-| `--api-key` | Read from `SN_API_KEY` env var | `--api-key "..."` | CLI argument has priority; throws `MissingApiKeyError` if env var and CLI value are both missing |
+| `--base-url` | Read from `SN_IMAGE_GEN_BASE_URL` env var | `--base-url "..."` | CLI argument has priority; throws error if env var and CLI value are both missing |
+| `--api-key` | Read from `SN_IMAGE_GEN_API_KEY` env var | `--api-key "..."` | CLI argument has priority; throws `MissingApiKeyError` if env var and CLI value are both missing |
 
 `sn-image-recognize` and `sn-text-optimize` use priority: **CLI argument > command-specific env var > shared `SN_CHAT_*` env var > built-in default**.
 

--- a/skills/sn-image-base/reference/api_spec.md
+++ b/skills/sn-image-base/reference/api_spec.md
@@ -37,7 +37,7 @@ python sn_agent_runner.py sn-image-generate \
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `--prompt` | string | **Yes** | - | Text prompt |
-| `--api-key` | string | No | Reads `SN_API_KEY` env var | API Key (CLI takes precedence; raises `MissingApiKeyError` if both are empty) |
+| `--api-key` | string | No | Reads `SN_IMAGE_GEN_API_KEY` env var | API Key (CLI takes precedence; raises `MissingApiKeyError` if both are empty) |
 | `--negative-prompt` | string | No | `""` | Negative prompt |
 | `--image-size` | string | No | `"2k"` | Image size: `1k` or `2k` |
 | `--aspect-ratio` | string | No | `"16:9"` | Aspect ratio |
@@ -80,18 +80,18 @@ Image generated successfully
 
 ### API Key Notes
 
-`--api-key` is optional. CLI parameter takes precedence; if not provided, reads from `SN_API_KEY` env var. If both are empty, raises `MissingApiKeyError`:
+`--api-key` is optional. CLI parameter takes precedence; if not provided, reads from `SN_IMAGE_GEN_API_KEY` env var. If both are empty, raises `MissingApiKeyError`:
 
 **text format**:
 
 ```
-Error: API key is required but was not provided. Set the SN_API_KEY environment variable or pass --api-key explicitly.
+Error: API key is required but was not provided. Set the SN_IMAGE_GEN_API_KEY environment variable or pass --api-key explicitly.
 ```
 
 **json format**:
 
 ```json
-{"status": "failed", "error": "API key is required but was not provided. Set the SN_API_KEY environment variable or pass --api-key explicitly.", "elapsed_seconds": 0.05}
+{"status": "failed", "error": "API key is required but was not provided. Set the SN_IMAGE_GEN_API_KEY environment variable or pass --api-key explicitly.", "elapsed_seconds": 0.05}
 ```
 
 ---
@@ -273,7 +273,7 @@ Error messages are written to stderr and do not affect stdout content.
 
 | Tool | Environment Variables (high → low priority) | Notes |
 |------|---------------------------------------------|-------|
-| `sn-image-generate` | `SN_API_KEY` | CLI takes precedence; reads this var if not provided; raises `MissingApiKeyError` if both are empty |
+| `sn-image-generate` | `SN_IMAGE_GEN_API_KEY` | CLI takes precedence; reads this var if not provided; raises `MissingApiKeyError` if both are empty |
 | `sn-image-recognize` | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` | CLI > command-specific key > shared chat key; raises `MissingApiKeyError` if all are empty |
 | `sn-text-optimize` | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` | CLI > command-specific key > shared chat key; raises `MissingApiKeyError` if all are empty |
 

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -103,12 +103,12 @@ def build_parser() -> argparse.ArgumentParser:
     gen_parser.add_argument("--seed", type=int, default=None, help="Random seed")
     gen_parser.add_argument("--unet-name", dest="unet_name", default=None, help="UNet model name")
     gen_parser.add_argument(
-        "--api-key", default="", help="API key (falls back to SN_API_KEY env var)"
+        "--api-key", default="", help="API key (falls back to SN_IMAGE_GEN_API_KEY env var)"
     )
     gen_parser.add_argument(
         "--base-url",
         default="",
-        help="API base URL (falls back to SN_BASE_URL env var)",
+        help="API base URL (falls back to SN_IMAGE_GEN_BASE_URL env var)",
     )
     gen_parser.add_argument("--poll-interval", type=float, default=5.0)
     gen_parser.add_argument("--timeout", type=float, default=300.0)
@@ -204,14 +204,14 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
             output (image path), task_id, and message. exit_code is 0 on
             success and 1 on failure.
     """
-    api_key = args.api_key or global_configs.SN_API_KEY
+    api_key = args.api_key or global_configs.SN_IMAGE_GEN_API_KEY
     if not api_key:
         raise MissingApiKeyError()
 
     base_url = args.base_url or global_configs.SN_IMAGE_GEN_BASE_URL
     if not base_url:
         raise InvalidBaseUrlError(
-            "No base URL provided. Set SN_BASE_URL env var or pass --base-url."
+            "No base URL provided. Set SN_IMAGE_GEN_BASE_URL env var or pass --base-url."
         )
 
     if global_configs.SN_IMAGE_GEN_MODEL_TYPE == "sensenova":

--- a/skills/sn-image-base/scripts/sn_image_base/configs.py
+++ b/skills/sn-image-base/scripts/sn_image_base/configs.py
@@ -87,9 +87,11 @@ class Configs:
     """
 
     # image-generate
-    SN_API_KEY: Annotated[str, Field("SN_API_KEY", required=True, secret=True)] = ""
+    SN_IMAGE_GEN_API_KEY: Annotated[
+        str, Field("SN_IMAGE_GEN_API_KEY", required=True, secret=True)
+    ] = ""
     SN_IMAGE_GEN_BASE_URL: Annotated[
-        str, Field("SN_IMAGE_GEN_BASE_URL", "SN_BASE_URL", required=True)
+        str, Field("SN_IMAGE_GEN_BASE_URL", required=True)
     ] = "https://token.sensenova.cn/v1"
     SN_IMAGE_GEN_MODEL_TYPE: Annotated[
         Literal["sensenova", "nano-banana", "openai-image"], Field("SN_IMAGE_GEN_MODEL_TYPE")

--- a/skills/sn-image-base/scripts/sn_image_base/exceptions.py
+++ b/skills/sn-image-base/scripts/sn_image_base/exceptions.py
@@ -25,7 +25,7 @@ class MissingApiKeyError(BadConfigurationError):
 
     DEFAULT_MESSAGE = (
         "API key is required but was not provided. "
-        "Set the SN_API_KEY environment variable or pass --api-key explicitly."
+        "Set the SN_IMAGE_GEN_API_KEY environment variable or pass --api-key explicitly."
     )
 
 

--- a/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
@@ -135,7 +135,7 @@ class NanoBananaText2ImageClient(T2IBaseClient):
             if exc.code == 404:
                 field_name = "SN_IMAGE_GEN_BASE_URL"
             elif exc.code == 401:
-                field_name = "SN_API_KEY"
+                field_name = "SN_IMAGE_GEN_API_KEY"
             if field_name is not None:
                 field_hint = global_configs.get_annotated_field(field_name)
                 if field_hint is not None:
@@ -186,10 +186,12 @@ class NanoBananaText2ImageClient(T2IBaseClient):
     @property
     @override
     def api_key(self) -> str:
-        api_key = self._api_key or global_configs.SN_API_KEY
+        api_key = self._api_key or global_configs.SN_IMAGE_GEN_API_KEY
         if not api_key:
             raise ValueError(
-                "API key is missing: {}".format(global_configs.get_env_var_help("SN_API_KEY"))
+                "API key is missing: {}".format(
+                    global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY")
+                )
             )
         return api_key
 

--- a/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
@@ -150,7 +150,7 @@ class OpenAIImageGenerationClient(T2IBaseClient):
             if exc.code == 404:
                 field_name = "SN_IMAGE_GEN_BASE_URL"
             elif exc.code == 401:
-                field_name = "SN_API_KEY"
+                field_name = "SN_IMAGE_GEN_API_KEY"
             if field_name is not None:
                 field_hint = global_configs.get_annotated_field(field_name)
                 if field_hint is not None:
@@ -200,10 +200,12 @@ class OpenAIImageGenerationClient(T2IBaseClient):
     @property
     @override
     def api_key(self) -> str:
-        api_key = self._api_key or global_configs.SN_API_KEY
+        api_key = self._api_key or global_configs.SN_IMAGE_GEN_API_KEY
         if not api_key:
             raise ValueError(
-                "API key is missing: {}".format(global_configs.get_env_var_help("SN_API_KEY"))
+                "API key is missing: {}".format(
+                    global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY")
+                )
             )
         return api_key
 

--- a/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
@@ -63,10 +63,12 @@ class SensenovaText2ImageClient(T2IBaseClient):
             ssl_verify (bool, optional):
                 If True, enable TLS verification. Defaults to True.
         """
-        api_key = api_key or global_configs.SN_API_KEY
+        api_key = api_key or global_configs.SN_IMAGE_GEN_API_KEY
         if not api_key:
             raise MissingApiKeyError(
-                "API key is missing: {}".format(global_configs.get_env_var_help("SN_API_KEY"))
+                "API key is missing: {}".format(
+                    global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY")
+                )
             )
         base_url = base_url or global_configs.SN_IMAGE_GEN_BASE_URL
         if not base_url:
@@ -159,7 +161,7 @@ class SensenovaText2ImageClient(T2IBaseClient):
             if exc.code == 404:
                 field_name = "SN_IMAGE_GEN_BASE_URL"
             elif exc.code == 401:
-                field_name = "SN_API_KEY"
+                field_name = "SN_IMAGE_GEN_API_KEY"
             # elif exc.code == 400:
             #     warnings.warn(f"Bad request: {exc.message}; body: {payload}", stacklevel=2)
             if field_name is not None:
@@ -211,10 +213,12 @@ class SensenovaText2ImageClient(T2IBaseClient):
     @property
     @override
     def api_key(self) -> str:
-        api_key = self._api_key or global_configs.SN_API_KEY
+        api_key = self._api_key or global_configs.SN_IMAGE_GEN_API_KEY
         if not api_key:
             raise ValueError(
-                "API key is missing: {}".format(global_configs.get_env_var_help("SN_API_KEY"))
+                "API key is missing: {}".format(
+                    global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY")
+                )
             )
         return api_key
 
@@ -291,7 +295,9 @@ class SensenovaText2ImageClient(T2IBaseClient):
     def headers(self) -> dict[str, str]:
         if not self.api_key:
             raise MissingApiKeyError(
-                "API key is missing: {}".format(global_configs.get_env_var_help("SN_API_KEY"))
+                "API key is missing: {}".format(
+                    global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY")
+                )
             )
         return {
             "Authorization": f"Bearer {self.api_key}",
@@ -488,7 +494,7 @@ if __name__ == "__main__":
 
     async def main_async():
         client = SensenovaText2ImageClient(
-            api_key=global_configs.SN_API_KEY,
+            api_key=global_configs.SN_IMAGE_GEN_API_KEY,
             base_url=global_configs.SN_IMAGE_GEN_BASE_URL,
         )
 

--- a/skills/sn-image-doctor/SKILL.md
+++ b/skills/sn-image-doctor/SKILL.md
@@ -60,15 +60,15 @@ python scripts/check_environment.py --verbose
   ✅ All required packages installed
 
 [3/3] Checking environment variables...
-  ❌ SN_API_KEY not set (required)
+  ❌ SN_IMAGE_GEN_API_KEY not set (required)
 
   Some required environment variables are missing.
   Enter values below to save them to /path/to/.env.
   Press Enter to skip a variable.
 
-  SN_API_KEY: <user input>
+  SN_IMAGE_GEN_API_KEY: <user input>
 
-  ✅ Saved to /path/to/.env: SN_API_KEY
+  ✅ Saved to /path/to/.env: SN_IMAGE_GEN_API_KEY
   🔄 Reloading environment...
   ✅ Environment reloaded successfully
 
@@ -79,7 +79,7 @@ python scripts/check_environment.py --verbose
 If reload fails, the output will suggest restarting the agent:
 
 ```
-  ✅ Saved to /path/to/.env: SN_API_KEY
+  ✅ Saved to /path/to/.env: SN_IMAGE_GEN_API_KEY
   🔄 Reloading environment...
   ⚠️  Failed to reload environment: <error message>
   💡 Suggestion: Restart the agent to apply new configuration
@@ -145,12 +145,12 @@ pip install -r skills/sn-image-base/requirements.txt
 
 ```bash
 # Set environment variables in your shell
-export SN_API_KEY="your-api-key"
+export SN_IMAGE_GEN_API_KEY="your-api-key"
 export SN_IMAGE_GEN_BASE_URL="https://your-api-endpoint.com"
 
 # Or create a .env file
 cat > .env << EOF
-SN_API_KEY=your-api-key
+SN_IMAGE_GEN_API_KEY=your-api-key
 SN_IMAGE_GEN_BASE_URL=https://token.sensenova.cn/v1
 SN_CHAT_API_KEY=your-chat-api-key
 SN_CHAT_BASE_URL=https://token.sensenova.cn/v1

--- a/skills/sn-image-doctor/scripts/check_environment.py
+++ b/skills/sn-image-doctor/scripts/check_environment.py
@@ -13,7 +13,7 @@ Checks performed:
    - All packages in sn-image-base/requirements.txt are installed
 
 3. Environment variables
-   Driven by sn_image_base.configs.Configs. Image generation uses SN_API_KEY,
+   Driven by sn_image_base.configs.Configs. Image generation uses SN_IMAGE_GEN_API_KEY,
    while text/vision chat calls use SN_CHAT_* with optional SN_TEXT_* and
    SN_VISION_* provider overrides.
 """

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -55,7 +55,7 @@ All API calls in this skill are executed through the `sn_agent_runner.py` of the
 |-----------|------|---------------------------|-------------|
 | **LLM** | sn-text-optimize (evaluation/expansion) | Default reads `SN_TEXT_API_KEY` / `SN_CHAT_API_KEY` environment variables | Built-in default points to Sensenova internal network service |
 | **VLM** | sn-image-recognize (image review) | Default reads `SN_VISION_API_KEY` / `SN_CHAT_API_KEY` environment variables | Built-in default points to Sensenova internal network service |
-| **Image Generation** | sn-image-generate | Default reads `SN_API_KEY` environment variable | Default uses image generation configuration of `sn-image-base` |
+| **Image Generation** | sn-image-generate | Default reads `SN_IMAGE_GEN_API_KEY` environment variable | Default uses image generation configuration of `sn-image-base` |
 
 **When encountering `MissingApiKeyError` or needing to specify a model**: pass explicitly via CLI parameters, parameter reference `$SN_IMAGE_BASE/reference/api_spec.md`.
 

--- a/skills/sn-ppt-doctor/SKILL.md
+++ b/skills/sn-ppt-doctor/SKILL.md
@@ -26,7 +26,7 @@ triggers:
 
 1. Text chat API key is available via `SN_TEXT_API_KEY` or shared `SN_CHAT_API_KEY`
 2. Vision chat API key is available via `SN_VISION_API_KEY` or shared `SN_CHAT_API_KEY`
-3. `SN_API_KEY` is set
+3. `SN_IMAGE_GEN_API_KEY` is set
 4. `sn-image-base` is discoverable and `sn_agent_runner.py --help` works
 5. `node --version` >= 18
 

--- a/skills/sn-ppt-doctor/ppt_doctor/check_environment.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/check_environment.py
@@ -10,7 +10,7 @@ self-contained design so OpenClaw can invoke it via a plain file path.
 
 Sections:
     1. CheckResult dataclass + shared helpers
-    2. Hard checks   (SN_CHAT_API_KEY or SN_TEXT/SN_VISION API keys, SN_API_KEY,
+    2. Hard checks   (SN_CHAT_API_KEY or SN_TEXT/SN_VISION API keys, SN_IMAGE_GEN_API_KEY,
                       SN_IMAGE_BASE discovery, sn_agent_runner executable,
                       Node >= 18)
     3. Soft checks   (PPT_DECK_ROOT writable, optional env vars,
@@ -135,12 +135,12 @@ def check_vision_chat_api_key() -> CheckResult:
 
 
 def check_u1_api_key() -> CheckResult:
-    val = _env("SN_API_KEY")
+    val = _env("SN_IMAGE_GEN_API_KEY")
     return CheckResult(
-        name="SN_API_KEY",
+        name="SN_IMAGE_GEN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_API_KEY is required for image generation calls",
+        detail="set" if val else "SN_IMAGE_GEN_API_KEY is required for image generation calls",
     )
 
 
@@ -297,7 +297,6 @@ def check_ppt_deck_root_writable() -> CheckResult:
 
 _OPTIONAL_VARS = [
     "SN_IMAGE_GEN_BASE_URL",
-    "SN_BASE_URL",
     "SN_IMAGE_GEN_MODEL",
     # NOTE: PPT_DECK_ROOT removed — deck_dir is now always $(cwd)/ppt_decks/
     "SN_IMAGE_GEN_MODEL_TYPE",
@@ -408,7 +407,7 @@ def run_all_checks() -> list[CheckResult]:
 
 REQUIRED = [
     ("SN_CHAT_API_KEY", "shared text/vision chat API key"),
-    ("SN_API_KEY", "Image generation API key"),
+    ("SN_IMAGE_GEN_API_KEY", "Image generation API key"),
 ]
 
 

--- a/skills/sn-ppt-doctor/ppt_doctor/checks.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/checks.py
@@ -88,12 +88,12 @@ def check_vision_chat_api_key() -> CheckResult:
 
 
 def check_u1_api_key() -> CheckResult:
-    val = _env("SN_API_KEY")
+    val = _env("SN_IMAGE_GEN_API_KEY")
     return CheckResult(
-        name="SN_API_KEY",
+        name="SN_IMAGE_GEN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_API_KEY is required for image generation calls",
+        detail="set" if val else "SN_IMAGE_GEN_API_KEY is required for image generation calls",
     )
 
 
@@ -263,7 +263,6 @@ def check_ppt_deck_root_writable() -> CheckResult:
 
 _OPTIONAL_VARS = [
     "SN_IMAGE_GEN_BASE_URL",
-    "SN_BASE_URL",
     "SN_IMAGE_GEN_MODEL",
     "SN_IMAGE_GEN_MODEL_TYPE",
     "SN_CHAT_BASE_URL",

--- a/skills/sn-ppt-doctor/ppt_doctor/interactive.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/interactive.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 REQUIRED = [
     ("SN_CHAT_API_KEY", "shared text/vision chat API key"),
-    ("SN_API_KEY", "Image generation API key"),
+    ("SN_IMAGE_GEN_API_KEY", "Image generation API key"),
 ]
 
 

--- a/skills/sn-ppt-entry/SKILL.md
+++ b/skills/sn-ppt-entry/SKILL.md
@@ -22,7 +22,7 @@ triggers:
 
 ## Hard preconditions
 
-Run `sn-ppt-doctor` hard checks (SN_CHAT_API_KEY or SN_TEXT/SN_VISION API keys / SN_API_KEY / node / sn-image-base) at the start of this skill. If any fails, stop and tell the user to run `/skill sn-ppt-doctor`.
+Run `sn-ppt-doctor` hard checks (SN_CHAT_API_KEY or SN_TEXT/SN_VISION API keys / SN_IMAGE_GEN_API_KEY / node / sn-image-base) at the start of this skill. If any fails, stop and tell the user to run `/skill sn-ppt-doctor`.
 
 ## Flow
 

--- a/skills/sn-ppt-entry/references/conventions.md
+++ b/skills/sn-ppt-entry/references/conventions.md
@@ -38,7 +38,7 @@ sn-ppt-standard 的 `scripts/run_stage.py` 对每个阶段都封装成 `python r
 
 必填变量：
 - `SN_CHAT_API_KEY`（LLM/VLM 默认共享 key；可用 `SN_TEXT_API_KEY` / `SN_VISION_API_KEY` 分别覆盖）
-- `SN_API_KEY` + `SN_IMAGE_GEN_BASE_URL`（或 `SN_BASE_URL`） + `SN_IMAGE_GEN_MODEL`
+- `SN_IMAGE_GEN_API_KEY` + `SN_IMAGE_GEN_BASE_URL` + `SN_IMAGE_GEN_MODEL`
 
 可选覆盖：`SN_CHAT_BASE_URL` / `SN_CHAT_TYPE` / `SN_CHAT_MODEL`、`SN_TEXT_*`、`SN_VISION_*`、`SN_CHAT_TIMEOUT` 等。
 

--- a/skills/sn-ppt-standard/SKILL.md
+++ b/skills/sn-ppt-standard/SKILL.md
@@ -112,7 +112,7 @@ The script is stateless — re-run a subcommand and it'll overwrite its output a
 Configured via `.env` at the repo root (or `<repo>/skills/.env`). `model_client.py` auto-loads both. Required:
 
 - `SN_CHAT_API_KEY` for shared text/vision chat auth, or per-kind overrides `SN_TEXT_API_KEY` / `SN_VISION_API_KEY`
-- `SN_API_KEY`, `SN_IMAGE_GEN_BASE_URL` (or `SN_BASE_URL`), `SN_IMAGE_GEN_MODEL`
+- `SN_IMAGE_GEN_API_KEY`, `SN_IMAGE_GEN_BASE_URL`, `SN_IMAGE_GEN_MODEL`
 
 Optional `SN_CHAT_BASE_URL` / `SN_TEXT_BASE_URL` / `SN_VISION_BASE_URL`, `SN_CHAT_MODEL` / `SN_TEXT_MODEL` / `SN_VISION_MODEL`, and `SN_CHAT_TIMEOUT` / `SN_TEXT_TIMEOUT` / `SN_VISION_TIMEOUT` override defaults.
 


### PR DESCRIPTION
…or image generation

- Replaced instances of `SN_API_KEY` with `SN_IMAGE_GEN_API_KEY` across documentation and scripts to standardize the environment variable for image generation.
- Updated relevant checks and error messages to reflect the new API key structure.
- Enhanced documentation to clarify the required environment variables for image generation and chat functionalities.