### PR TITLE
docs: fix infographic gallery image width attribute

### DIFF
--- a/docs/sn-infographic-examples_CN.md
+++ b/docs/sn-infographic-examples_CN.md
@@ -1,7 +1,7 @@
 # sn-infographic 案例库
 
 <p align="center">
-  <img src="images/teasers/cases_merge.webp" width=95%">
+  <img src="images/teasers/cases_merge.webp" width="95%">
 </p>
 
 


### PR DESCRIPTION
## Summary
- Fix malformed `width` attribute in the Chinese infographic gallery teaser image.

## Verification
- `git diff --check origin/main...HEAD`
- Confirmed branch diff is limited to `docs/sn-infographic-examples_CN.md` with one line changed.