### PR TITLE
docs(readme): restructure How-to-Use intro as bulleted recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Raccoon now ships a full upgrade across product capability and client experience
 
 ## How to Use
 
-**These skills are designed to run inside an [Agent Skills](https://agentskills.io/)-compatible agent — for the best experience, pair them with [OpenClaw](https://openclaw.ai/) or [hermes-agent](https://github.com/NousResearch/hermes-agent). See [`INSTALL.md`](INSTALL.md) for the full install + LLM configuration walkthrough.**
+These skills are designed to run inside an [Agent Skills](https://agentskills.io/)-compatible agent.
+
+- **Recommended runtime**: pair them with **[OpenClaw](https://openclaw.ai/)** or **[hermes-agent](https://github.com/NousResearch/hermes-agent)**.
+- **Recommended LLM**: pair them with the **[SenseNova Platform API](https://platform.sensenova.cn/token-plan)** — a free token plan is available.
+- **Install & configure**: follow the full walkthrough in **[`INSTALL.md`](INSTALL.md)**.
 
 Clone this repository, then copy subdirectories under `skills/` into the skills directory your agent loads from:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -32,7 +32,11 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 
 ## 如何使用
 
-**本仓库的 skill 需要配合支持 [Agent Skills](https://agentskills.io/) 规范的智能体使用，推荐 [OpenClaw](https://openclaw.ai/) 或 [hermes-agent](https://github.com/NousResearch/hermes-agent) 获得最佳效果。完整的安装、LLM 配置与 skill 加载流程请参考 [`INSTALL_CN.md`](INSTALL_CN.md)。**
+本仓库的 skill 需要配合支持 [Agent Skills](https://agentskills.io/) 规范的智能体使用。
+
+- **推荐运行时**：**[OpenClaw](https://openclaw.ai/)** 或 **[hermes-agent](https://github.com/NousResearch/hermes-agent)**。
+- **推荐 LLM**：配合使用 **[SenseNova 平台 API](https://platform.sensenova.cn/token-plan)**（提供免费 token 套餐）。
+- **安装与配置**：完整流程请参考 **[`INSTALL_CN.md`](INSTALL_CN.md)**。
 
 克隆本仓库后，把 `skills/` 下的子目录复制（或软链接）到所用智能体加载的 skills 目录：
 


### PR DESCRIPTION
## Summary
- Split the bold one-liner under **How to Use** in `README.md` and **如何使用** in `README_CN.md` into three bulleted recommendations.
- Promote the **SenseNova Platform API** (https://platform.sensenova.cn/token-plan) as the recommended LLM pairing alongside OpenClaw / hermes-agent.
- Keep **INSTALL.md** / **INSTALL_CN.md** as the canonical install + LLM configuration reference.

## Test plan
- [ ] Render `README.md` and `README_CN.md` on GitHub and confirm the three bullets display with bold emphasis on runtime / LLM / install links.
- [ ] Click each link (Agent Skills, OpenClaw, hermes-agent, SenseNova token-plan, INSTALL.md / INSTALL_CN.md) and confirm it lands on the intended target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)