### PR TITLE
docs(readme): recommend letting the agent install skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,21 @@ These skills are designed to run inside an [Agent Skills](https://agentskills.io
 - **Recommended LLM**: pair them with the **[SenseNova Platform API](https://platform.sensenova.cn/token-plan)** — a free token plan is available.
 - **Install & configure**: follow the full walkthrough in **[`INSTALL.md`](INSTALL.md)**.
 
-Clone this repository, then copy subdirectories under `skills/` into the skills directory your agent loads from:
+**Recommended: let the agent install the skills for you.** Hand it the repo URL and ask it to clone and drop the skills into the right directory — for example:
+
+> *"Please install SenseNova-Skills from https://github.com/OpenSenseNova/SenseNova-Skills into your skills directory."*
+
+After it finishes, **you may need to manually restart the agent service** before the new skills are picked up.
 
 | Agent | Target directory |
 |-------|------------------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
 | [hermes-agent](https://github.com/NousResearch/hermes-agent) | `~/.hermes/skills/` |
 
-For example, copy all skills into OpenClaw:
+<details>
+<summary>Prefer to install manually?</summary>
+
+Clone this repository, then copy the subdirectories under `skills/` into the target directory yourself:
 
 ```bash
 git clone https://github.com/OpenSenseNova/SenseNova-Skills.git --depth=1
@@ -53,6 +60,8 @@ cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
 For Hermes, swap the target to `~/.hermes/skills/`.
+
+</details>
 
 Per-category Python dependencies, API keys, and invocation examples are documented in the 📖 Full guide for each section.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -38,14 +38,21 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 - **推荐 LLM**：配合使用 **[SenseNova 平台 API](https://platform.sensenova.cn/token-plan)**（提供免费 token 套餐）。
 - **安装与配置**：完整流程请参考 **[`INSTALL_CN.md`](INSTALL_CN.md)**。
 
-克隆本仓库后，把 `skills/` 下的子目录复制（或软链接）到所用智能体加载的 skills 目录：
+**推荐做法：直接让 agent 帮你装好这些 skill。** 把仓库地址交给它，让它自己克隆并把内容拷贝到目标目录，例如：
+
+> *"请帮我把 https://github.com/OpenSenseNova/SenseNova-Skills 安装到你的 skills 目录。"*
+
+安装完成后，**可能需要手动重启 agent 服务**，新 skill 才会被加载。
 
 | 智能体 | 目标目录 |
 |--------|---------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
 | [hermes-agent](https://github.com/NousResearch/hermes-agent) | `~/.hermes/skills/` |
 
-例如，把全部技能复制到 OpenClaw：
+<details>
+<summary>想手动安装？</summary>
+
+克隆本仓库，然后把 `skills/` 下的子目录自行复制（或软链接）到目标目录：
 
 ```bash
 git clone https://github.com/OpenSenseNova/SenseNova-Skills.git --depth=1
@@ -54,6 +61,8 @@ cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
 Hermes 把目录换成 `~/.hermes/skills/` 即可。
+
+</details>
 
 各分类技能的 Python 依赖、API key 与调用示例同样请参考对应分类的 📖 详细使用指南。
 


### PR DESCRIPTION
## Summary
- Promote the agent-driven install flow as the recommended way to land SenseNova-Skills: hand the agent the repo URL and let it clone + copy the skills into the right directory, with an example prompt.
- Call out that **users may need to manually restart the agent service** after install so the new skills get picked up.
- Fold the prior `git clone` + `cp` recipe into a collapsed `<details>` block as a manual-install fallback.
- Apply the same restructure to `README_CN.md` to keep CN/EN aligned.

## Test plan
- [ ] Render `README.md` and `README_CN.md` on GitHub and confirm the agent-driven instructions, the bold restart warning, and the collapsed `<details>` block all display correctly.
- [ ] Try the example prompt in OpenClaw / hermes-agent and confirm the agent successfully clones the repo and lands the skills under `~/.openclaw/skills/` or `~/.hermes/skills/`.
- [ ] After restarting the agent service, confirm the newly installed skills are discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)