### PR TITLE
fix: Document sn-image-base base URL handling

### DIFF
--- a/skills/sn-image-base/README.md
+++ b/skills/sn-image-base/README.md
@@ -150,6 +150,12 @@ The default values are recommended for the [SenseNova](https://platform.sensenov
 
 Configure `SN_TEXT_*` or `SN_VISION_*` only when a command needs a different provider than the shared `SN_CHAT_*` provider.
 
+For chat calls, the runner also accepts host-only base URLs such as
+`https://token.sensenova.cn`: if no URL path is present, it appends the API
+version path before the interface endpoint. Prefer the documented versioned
+base URL, for example `https://token.sensenova.cn/v1`, for consistency with the
+built-in defaults.
+
 To use non-default shared chat settings, please:
 
 1. Set `SN_CHAT_TYPE` according to the chat API protocol. Available values are:

--- a/skills/sn-image-base/README_CN.md
+++ b/skills/sn-image-base/README_CN.md
@@ -150,6 +150,11 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 
 仅当文本或视觉命令需要使用不同 provider 时，才需要配置 `SN_TEXT_*` 或 `SN_VISION_*`。
 
+对于 chat 调用，runner 也兼容不带路径的 host-only base URL，例如
+`https://token.sensenova.cn`：如果 URL 中没有 path，会先补上 API 版本路径再追加具体接口。
+为保持和内置默认值一致，建议优先使用带版本路径的 base URL，例如
+`https://token.sensenova.cn/v1`。
+
 如需使用非默认 chat 设置，请按以下步骤：
 
 1. 按 chat API 协议设置 `SN_CHAT_TYPE`。可选值如下：

--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -200,19 +200,19 @@ Mapping between `provider.api` and interface type:
 
 Different API types have different requirements for base-url format:
 
-| Type | `--llm-type` / `--vlm-type` | base-url Example | Code Appended Path | Final URL Example |
+| Type | `--llm-type` / `--vlm-type` | Recommended base-url | Code Appended Path | Final URL Example |
 |------|------------------------------|---------------|--------------|---------------|
-| LLM | `openai-completions` | `https://token.sensenova.cn` | `/v1/chat/completions` | `https://token.sensenova.cn/v1/chat/completions` |
-| LLM | `anthropic-messages` | `https://api.anthropic.com` | `/v1/messages` | `https://api.anthropic.com/v1/messages` |
-| VLM | `openai-completions` | `https://token.sensenova.cn` | `/v1/chat/completions` | `https://token.sensenova.cn/v1/chat/completions` |
-| VLM | `anthropic-messages` | `https://api.anthropic.com` | `/v1/messages` | `https://api.anthropic.com/v1/messages` |
+| LLM | `openai-completions` | `https://token.sensenova.cn/v1` | `/chat/completions` | `https://token.sensenova.cn/v1/chat/completions` |
+| LLM | `anthropic-messages` | `https://api.anthropic.com/v1` | `/messages` | `https://api.anthropic.com/v1/messages` |
+| VLM | `openai-completions` | `https://token.sensenova.cn/v1` | `/chat/completions` | `https://token.sensenova.cn/v1/chat/completions` |
+| VLM | `anthropic-messages` | `https://api.anthropic.com/v1` | `/messages` | `https://api.anthropic.com/v1/messages` |
 
 **Note**:
 
-- `openai-completions` interface: code automatically appends `/v1/chat/completions`
-- `anthropic-messages` interface: code automatically appends `/v1/messages`
-- Some providers require base-url with `/v1`, while others do not, depending on provider implementation
-- If unsure, prefer not adding `/v1` because the code appends it automatically
+- Recommended chat base URLs include the provider API version path, for example `/v1`.
+- For compatibility, if the configured chat base URL has no path, the runner appends `/v1/chat/completions` or `/v1/messages`.
+- If the configured chat base URL already has a path such as `/v1`, the runner appends only `/chat/completions` or `/messages`.
+- Some providers use versioned paths other than `/v1`, such as Gemini's `/v1beta/openai`.
 
 ## Output Format
 
@@ -228,7 +228,7 @@ JSON output for `sn-image-recognize` and `sn-text-optimize` also includes `model
   "status": "ok",
   "result": "...",
   "model": "sensenova-6.7-flash-lite",
-  "base_url": "https://token.sensenova.cn",
+  "base_url": "https://token.sensenova.cn/v1",
   "interface_type": "openai-completions",
   "elapsed_seconds": 1.23
 }

--- a/skills/sn-image-base/references/api_spec.md
+++ b/skills/sn-image-base/references/api_spec.md
@@ -150,7 +150,7 @@ This image shows an adorable orange cat napping in the sunlight.
   "status": "ok",
   "result": "This image shows an adorable orange cat napping in the sunlight.",
   "model": "sensenova-6.7-flash-lite",
-  "base_url": "https://token.sensenova.cn",
+  "base_url": "https://token.sensenova.cn/v1",
   "interface_type": "openai-completions",
   "elapsed_seconds": 2.15
 }
@@ -166,6 +166,11 @@ This image shows an adorable orange cat napping in the sunlight.
 | `--base-url` | `https://token.sensenova.cn/v1` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` |
 | `--model` | `sensenova-6.7-flash-lite` | `SN_VISION_MODEL` -> `SN_CHAT_MODEL` |
 | `--vlm-type` | `openai-completions` | `SN_VISION_TYPE` -> `SN_CHAT_TYPE` |
+
+Compatibility note: host-only chat base URLs such as `https://token.sensenova.cn`
+are also accepted. If the base URL has no path, the runner inserts `/v1` before
+the interface endpoint; if it already has a path such as `/v1`, the runner
+appends only the interface endpoint path.
 
 ---
 
@@ -221,7 +226,7 @@ Optimized text content...
   "status": "ok",
   "result": "Optimized text content...",
   "model": "sensenova-6.7-flash-lite",
-  "base_url": "https://token.sensenova.cn",
+  "base_url": "https://token.sensenova.cn/v1",
   "interface_type": "openai-completions",
   "elapsed_seconds": 0.83
 }
@@ -237,6 +242,11 @@ Optimized text content...
 | `--base-url` | `https://token.sensenova.cn/v1` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` |
 | `--model` | `sensenova-6.7-flash-lite` | `SN_TEXT_MODEL` -> `SN_CHAT_MODEL` |
 | `--llm-type` | `openai-completions` | `SN_TEXT_TYPE` -> `SN_CHAT_TYPE` |
+
+Compatibility note: host-only chat base URLs such as `https://token.sensenova.cn`
+are also accepted. If the base URL has no path, the runner inserts `/v1` before
+the interface endpoint; if it already has a path such as `/v1`, the runner
+appends only the interface endpoint path.
 
 ---
 


### PR DESCRIPTION
## Summary

- Standardize sn-image-base documentation examples on versioned base URLs such as `https://token.sensenova.cn/v1`.
- Clarify the chat runner compatibility behavior for host-only base URLs.
- Update API spec JSON examples to match the built-in defaults.

## Why

The docs mixed base URL examples with and without `/v1`, which made it unclear which value should be configured. The runtime supports both forms for chat calls, but the recommended documented default should match the code defaults.

## Validation

- `git diff --cached --check`
- `gitnexus_detect_changes(scope="staged")` before commit: low risk, no affected execution flows
- `npx gitnexus analyze` after commit
