### PR TITLE
fix: remove 1k image size option

### DIFF
--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -48,7 +48,7 @@ Image generation tool that calls the text-to-image-no-enhance API.
 |------|------|--------|------|
 | `--prompt` | string | **Required** | Prompt text for image generation |
 | `--negative-prompt` | string | `""` | Negative prompt |
-| `--image-size` | string | `2k` | Image size preset, supports `1k` and `2k` |
+| `--image-size` | string | `2k` | Image size preset, supports `2k` only |
 | `--aspect-ratio` | string | `16:9` | Aspect ratio, e.g. `1:1`, `16:9`, `9:16` |
 | `--seed` | int | `None` | Random seed for reproducible generation |
 | `--unet-name` | string | `None` | Specify a UNet model name |

--- a/skills/sn-image-base/references/api_spec.md
+++ b/skills/sn-image-base/references/api_spec.md
@@ -21,7 +21,7 @@ python sn_agent_runner.py sn-image-generate \
     [--api-key <string>] \
     [--base-url <string>] \
     [--negative-prompt <string>] \
-    [--image-size 1k|2k] \
+    [--image-size 2k] \
     [--aspect-ratio <string>] \
     [--seed <int>] \
     [--unet-name <string>] \
@@ -39,7 +39,7 @@ python sn_agent_runner.py sn-image-generate \
 | `--prompt` | string | **Yes** | - | Text prompt |
 | `--api-key` | string | No | Reads `SN_IMAGE_GEN_API_KEY` env var | API Key (CLI takes precedence; raises `MissingApiKeyError` if both are empty) |
 | `--negative-prompt` | string | No | `""` | Negative prompt |
-| `--image-size` | string | No | `"2k"` | Image size: `1k` or `2k` |
+| `--image-size` | string | No | `"2k"` | Image size: `2k` only |
 | `--aspect-ratio` | string | No | `"16:9"` | Aspect ratio |
 | `--seed` | int | No | `None` | Random seed (for reproducibility) |
 | `--unet-name` | string | No | `None` | UNet model name |

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -80,7 +80,7 @@ def build_parser() -> argparse.ArgumentParser:
     gen_parser.add_argument("--prompt", required=True, help="Text prompt for image generation")
     gen_parser.add_argument("--negative-prompt", default="", help="Negative prompt")
     gen_parser.add_argument(
-        "--image-size", default="2k", choices=["1k", "2k"], help="Image size preset"
+        "--image-size", default="2k", choices=["2k"], help="Image size preset"
     )
     gen_parser.add_argument(
         "--aspect-ratio",


### PR DESCRIPTION
### Motivation
- Simplify and standardize image generation presets by removing the `1k` option so the pipeline only exposes `2k`.
- Ensure documentation and API spec remain accurate and consistent with the CLI behavior.

### Description
- Changed the `sn-image-generate` CLI `--image-size` choices in `skills/sn-image-base/scripts/sn_agent_runner.py` from `["1k", "2k"]` to `["2k"]`.
- Updated the skill documentation `skills/sn-image-base/SKILL.md` to state the `--image-size` parameter supports `2k` only.
- Updated the API reference `skills/sn-image-base/references/api_spec.md` to remove `1k` from the command synopsis and parameter description.

### Testing
- Ran `python -m py_compile skills/sn-image-base/scripts/sn_agent_runner.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c73628ac832d9642bb2761b88423)