### PR TITLE
feat: Add global SN API fallback configuration

### DIFF
--- a/docs/deep-research.md
+++ b/docs/deep-research.md
@@ -63,7 +63,7 @@
 | 抖音 | **必填** | `DOUYIN_COOKIE` | 不配置无法搜索 |
 | Twitter/X | **必填** | `TIKHUB_TOKEN` | 通过 TikHub 反代 |
 | YouTube | **必填** | `YOUTUBE_API_KEY` | YouTube Data API v3 |
-| AI 配图（`sn-image-base` / `sn-image-generate`） | 生成配图时**必填** | `SN_IMAGE_GEN_API_KEY` | 用于 `report.md` 中的 AI 配图 |
+| AI 配图（`sn-image-base` / `sn-image-generate`） | 生成配图时**必填** | `SN_API_KEY` | 用于 `report.md` 中的 AI 配图；`SN_IMAGE_GEN_API_KEY` 仅在图像生成使用不同 key 时覆盖 |
 | AI 配图模型 | 可选 | `SN_IMAGE_GEN_MODEL` | 默认见 `sn-image-base` 配置；可指定 Token Plan 或其他支持的图像模型 |
 | AI 配图服务地址 | 可选 | `SN_IMAGE_GEN_BASE_URL` | 默认见 `sn-image-base` 配置；使用非默认服务时设置 |
 | AI 配图模型类型 | 可选 | `SN_IMAGE_GEN_MODEL_TYPE` | 如 `sensenova`、`nano-banana`、`openai-image` |
@@ -73,8 +73,8 @@ ArXiv、Stack Overflow、Hacker News、Reddit 公开搜索无需 key。
 `sn-image-generate` 相关最小配置示例：
 
 ```ini
-SN_IMAGE_GEN_API_KEY="sk-xxx"
-SN_IMAGE_GEN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="sk-xxx"
+SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_IMAGE_GEN_MODEL_TYPE="sensenova"
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"
 ```

--- a/docs/deep-research_en.md
+++ b/docs/deep-research_en.md
@@ -63,7 +63,7 @@ Set as needed in `~/.openclaw/.env` (OpenClaw), `~/.hermes/.env` (Hermes), or th
 | Douyin | **Required** | `DOUYIN_COOKIE` | Search will not work without it |
 | Twitter/X | **Required** | `TIKHUB_TOKEN` | Routed via TikHub |
 | YouTube | **Required** | `YOUTUBE_API_KEY` | YouTube Data API v3 |
-| AI illustrations (`sn-image-base` / `sn-image-generate`) | **Required** when generating images | `SN_IMAGE_GEN_API_KEY` | Used for AI illustrations in `report.md` |
+| AI illustrations (`sn-image-base` / `sn-image-generate`) | **Required** when generating images | `SN_API_KEY` | Used for AI illustrations in `report.md`; `SN_IMAGE_GEN_API_KEY` is only needed when image generation uses a different key |
 | AI image model | Optional | `SN_IMAGE_GEN_MODEL` | Defaults are defined by `sn-image-base`; set this for a specific Token Plan or other supported image model |
 | AI image base URL | Optional | `SN_IMAGE_GEN_BASE_URL` | Defaults are defined by `sn-image-base`; set this for non-default providers |
 | AI image model type | Optional | `SN_IMAGE_GEN_MODEL_TYPE` | Examples: `sensenova`, `nano-banana`, `openai-image` |
@@ -73,8 +73,8 @@ ArXiv, Stack Overflow, Hacker News, and Reddit public search require no key.
 Minimal `sn-image-generate` configuration example:
 
 ```ini
-SN_IMAGE_GEN_API_KEY="sk-xxx"
-SN_IMAGE_GEN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="sk-xxx"
+SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_IMAGE_GEN_MODEL_TYPE="sensenova"
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"
 ```

--- a/docs/ppt-generate.md
+++ b/docs/ppt-generate.md
@@ -45,22 +45,20 @@ pip install -r skills/sn-image-base/requirements.txt
 将以下变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
 
 ```ini
+# 如果所有能力走同一个网关，只需要配置这两个变量
+SN_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+
 # LLM（大纲、style_spec、内容规划、图片内容识别、页面review）
-SN_CHAT_API_KEY="your-api-key"
-SN_CHAT_BASE_URL="https://token.sensenova.cn/v1"
 SN_CHAT_MODEL="sensenova-6.7-flash-lite"
-SN_VISION_API_KEY="your-api-key"
-SN_VISION_BASE_URL="https://token.sensenova.cn/v1"
 SN_VISION_MODEL="sensenova-6.7-flash-lite"
 
 # 文生图（创意模式必填，标准模式按需）
-SN_IMAGE_GEN_API_KEY="your-api-key"
 SN_IMAGE_GEN_MODEL_TYPE="sensenova"
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"
-SN_IMAGE_GEN_BASE_URL="https://token.sensenova.cn/v1"
 ```
 
-可选环境变量：`SN_IMAGE_GEN_*`、`SN_TEXT_*`、`SN_VISION_*` 用于覆盖默认模型与超时。详细列表见 [`skills/sn-image-base/README.md`](../skills/sn-image-base/README.md)。
+可选环境变量：`SN_IMAGE_GEN_*`、`SN_CHAT_*`、`SN_TEXT_*`、`SN_VISION_*` 用于覆盖默认模型、网关或 key。已有 `SN_API_KEY` 时，不需要再设置 `SN_IMAGE_GEN_API_KEY`，除非图像生成使用不同 key。详细列表见 [`skills/sn-image-base/README.md`](../skills/sn-image-base/README.md)。
 
 调用前先运行环境诊断：
 

--- a/docs/ppt-generate_en.md
+++ b/docs/ppt-generate_en.md
@@ -45,22 +45,20 @@ pip install -r skills/sn-image-base/requirements.txt
 Set the following in `~/.openclaw/.env` (OpenClaw) or `~/.hermes/.env` (Hermes):
 
 ```ini
+# If all capabilities use the same gateway, these two variables are enough.
+SN_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+
 # LLM (outline, style_spec, content planning, image caption, page review)
-SN_CHAT_API_KEY="your-api-key"
-SN_CHAT_BASE_URL="https://token.sensenova.cn/v1"
 SN_CHAT_MODEL="sensenova-6.7-flash-lite"
-SN_VISION_API_KEY="your-api-key"
-SN_VISION_BASE_URL="https://token.sensenova.cn/v1"
 SN_VISION_MODEL="sensenova-6.7-flash-lite"
 
 # Text-to-image (required for creative mode, on-demand for standard mode)
-SN_IMAGE_GEN_API_KEY="your-api-key"
 SN_IMAGE_GEN_MODEL_TYPE="sensenova"
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"
-SN_IMAGE_GEN_BASE_URL="https://token.sensenova.cn/v1"
 ```
 
-Optional variables `SN_IMAGE_GEN_*`, `SN_TEXT_*`, and `SN_VISION_*` override default models and timeouts. Full list: [`skills/sn-image-base/README.md`](../skills/sn-image-base/README.md).
+Optional variables `SN_IMAGE_GEN_*`, `SN_CHAT_*`, `SN_TEXT_*`, and `SN_VISION_*` override default models, gateways, or keys. If `SN_API_KEY` is set, `SN_IMAGE_GEN_API_KEY` is not needed unless image generation uses a different key. Full list: [`skills/sn-image-base/README.md`](../skills/sn-image-base/README.md).
 
 Run environment doctor before invoking:
 

--- a/docs/sn-image-generate.md
+++ b/docs/sn-image-generate.md
@@ -7,7 +7,7 @@
 ## 环境要求
 
 - **Python** 3.9 或更高版本（推荐 3.10+）。
-- **SN API** 凭据，用于图像生成与 LLM/VLM 接口（`SN_IMAGE_GEN_API_KEY`、`SN_CHAT_API_KEY`，详见 Quick Start）。
+- **SN API** 凭据，用于图像生成与 LLM/VLM 接口（所有能力走同一网关时，`SN_BASE_URL` 和 `SN_API_KEY` 即可；详见 Quick Start）。
 
 ## 技能介绍
 
@@ -103,9 +103,11 @@ pip install -r skills/sn-image-base/requirements.txt
 将以下环境变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
 
 ```ini
-SN_IMAGE_GEN_API_KEY="your-api-key"
-SN_CHAT_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="your-api-key"
 ```
+
+环境变量 fallback 优先级为：专用变量 > 领域共享变量 > 全局变量。若某个能力需要不同 provider，可再设置 `SN_TEXT_*`、`SN_VISION_*`、`SN_CHAT_*` 或 `SN_IMAGE_GEN_*`。
 
 **注意：** 切勿将 `.env` 或 API Key 提交到 git。
 

--- a/docs/sn-image-generate_en.md
+++ b/docs/sn-image-generate_en.md
@@ -7,7 +7,7 @@ This document collects the SN (SenseNova) related skills (`sn-image-doctor`, `sn
 ## Prerequisites
 
 - **Python** 3.9 or later (3.10+ recommended).
-- **SN API** credentials for image generation and LLM/VLM endpoints (`SN_IMAGE_GEN_API_KEY`, `SN_CHAT_API_KEY`; see Quick Start).
+- **SN API** credentials for image generation and LLM/VLM endpoints (`SN_BASE_URL` and `SN_API_KEY` are enough when all capabilities use one gateway; see Quick Start).
 
 ## Skills
 
@@ -103,9 +103,11 @@ Go to <https://platform.sensenova.cn/token-plan/> to register a free account and
 Set the following environment variables in `~/.openclaw/.env` (for OpenClaw) or `~/.hermes/.env` (for Hermes):
 
 ```ini
-SN_IMAGE_GEN_API_KEY="your-api-key"
-SN_CHAT_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="your-api-key"
 ```
+
+Fallback priority is dedicated variable > domain shared variable > global variable. If a capability needs a different provider, set `SN_TEXT_*`, `SN_VISION_*`, `SN_CHAT_*`, or `SN_IMAGE_GEN_*`.
 
 **Note:** Never commit `.env` files or API keys to git.
 

--- a/skills/sn-image-base/README.md
+++ b/skills/sn-image-base/README.md
@@ -39,11 +39,12 @@ Go to <https://platform.sensenova.cn/token-plan/> to register a free account and
 Set the following environment variables in `~/.openclaw/.env` (or `~/.hermes/.env` if you are using Hermes):
 
 ```ini
-# Image generation
-SN_IMAGE_GEN_API_KEY="<sensenova-token-plan-api-key>"
+# If all capabilities use the same gateway, these two variables are enough.
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="<sensenova-token-plan-api-key>"
+
+# Optional model overrides
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"   # or other image generation models available in the SenseNova Token Plan
-# Text and vision chat runtime
-SN_CHAT_API_KEY="<sensenova-token-plan-api-key>"
 SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ```
 
@@ -69,18 +70,29 @@ Multiple sources of configuration are supported, the priority is (high to low):
 
 #### Image Generation
 
+Environment variables are resolved as: dedicated variable > domain shared variable > global variable.
+
+| Capability | API key fallback | Base URL fallback |
+| ---------- | ---------------- | ----------------- |
+| Text model | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
+| Vision model | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
+| Image generation | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` |
+
 Full configuration for image generation:
 
 | Config Key | Description | Default |
 | ---------- | ----------- | ------- |
-| `SN_IMAGE_GEN_API_KEY` | The API key for the SenseNova Token Plan | (Required) |
+| `SN_API_KEY` | Global API key used when capability-specific keys are unset | `""` |
+| `SN_BASE_URL` | Global base URL used when capability-specific base URLs are unset | `""` |
+| `SN_IMAGE_GEN_API_KEY` | Optional image-generation-only API key override | `SN_API_KEY` |
 | `SN_IMAGE_GEN_MODEL_TYPE` | The type of image generation model to use | `"sensenova"` |
 | `SN_IMAGE_GEN_MODEL` | The name of the image generation model to use | `"sensenova-u1-fast"` |
-| `SN_IMAGE_GEN_BASE_URL` | The base URL for the image generation API | `"https://token.sensenova.cn/v1"` |
+| `SN_IMAGE_GEN_BASE_URL` | The base URL for the image generation API | `SN_BASE_URL`, then `"https://token.sensenova.cn/v1"` |
 
 The default values are recommended for the [SenseNova](https://platform.sensenova.cn/).
 
-You only need to set the `SN_IMAGE_GEN_API_KEY`, and optionally set `SN_IMAGE_GEN_MODEL` to the model name provided by the token plan.
+When all capabilities use one gateway, set only `SN_BASE_URL` and `SN_API_KEY`.
+Set `SN_IMAGE_GEN_*` only when image generation needs a different provider.
 
 To use non-default image generation models, please:
 
@@ -117,7 +129,7 @@ To use non-default image generation models, please:
     SN_IMAGE_GEN_MODEL="gpt-image-2"
     ```
 
-4. (**Required**) Set `SN_IMAGE_GEN_API_KEY` to the API key for the image generation API.
+4. If image generation uses a different key than the global key, set `SN_IMAGE_GEN_API_KEY`. If `SN_API_KEY` already works for image generation, skip this.
 
     ```ini
     SN_IMAGE_GEN_API_KEY="sk-your-image-generation-api-key"
@@ -133,16 +145,16 @@ models only when needed:
 
 | Config Keys | Description | Default |
 | ----------- | ----------- | ------- |
-| `SN_CHAT_API_KEY` | API key for text and vision chat calls | (Required) |
-| `SN_CHAT_BASE_URL` | Shared base URL for the chat API | `"https://token.sensenova.cn/v1"` |
+| `SN_CHAT_API_KEY` | API key for text and vision chat calls | `SN_API_KEY` |
+| `SN_CHAT_BASE_URL` | Shared base URL for the chat API | `SN_BASE_URL`, then `"https://token.sensenova.cn/v1"` |
 | `SN_CHAT_TYPE` | Shared chat protocol type | `"openai-completions"` |
 | `SN_CHAT_MODEL` | Shared default model for text and vision chat calls | `"sensenova-6.7-flash-lite"` |
-| `SN_TEXT_API_KEY` | Optional text-only provider API key | `SN_CHAT_API_KEY` |
-| `SN_TEXT_BASE_URL` | Optional text-only provider base URL | `SN_CHAT_BASE_URL` |
+| `SN_TEXT_API_KEY` | Optional text-only provider API key | `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `SN_TEXT_BASE_URL` | Optional text-only provider base URL | `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `SN_TEXT_TYPE` | Optional text-only protocol type | `SN_CHAT_TYPE` |
 | `SN_TEXT_MODEL` | Optional model override for `sn-text-optimize` | `SN_CHAT_MODEL` |
-| `SN_VISION_API_KEY` | Optional vision provider API key | `SN_CHAT_API_KEY` |
-| `SN_VISION_BASE_URL` | Optional vision provider base URL | `SN_CHAT_BASE_URL` |
+| `SN_VISION_API_KEY` | Optional vision provider API key | `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `SN_VISION_BASE_URL` | Optional vision provider base URL | `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `SN_VISION_TYPE` | Optional vision protocol type | `SN_CHAT_TYPE` |
 | `SN_VISION_MODEL` | Optional vision-capable model override for `sn-image-recognize` | `SN_CHAT_MODEL` |
 
@@ -193,7 +205,7 @@ To use non-default shared chat settings, please:
     SN_TEXT_MODEL="gpt-5.5"
     ```
 
-4. (**Required**) Set `SN_CHAT_API_KEY` to the API key for the shared chat endpoint.
+4. Set `SN_CHAT_API_KEY` to the API key for the shared chat endpoint, or use global `SN_API_KEY`.
 
     ```ini
     SN_CHAT_API_KEY="sk-your-api-key"
@@ -204,12 +216,12 @@ To use non-default shared chat settings, please:
 ### Missing API key
 
 - Symptom: errors like "required but not set", "missing api key", or request unauthorized.
-- Fix: set `SN_IMAGE_GEN_API_KEY` for image generation, and set `SN_CHAT_API_KEY` for chat calls. Use `SN_TEXT_API_KEY` or `SN_VISION_API_KEY` when text and vision use different providers.
+- Fix: set global `SN_API_KEY` when all capabilities use one key. Do not also set `SN_IMAGE_GEN_API_KEY` unless image generation needs a different provider or key. Use `SN_CHAT_API_KEY`, `SN_TEXT_API_KEY`, or `SN_VISION_API_KEY` only when chat/text/vision needs a different provider.
 
 ### Wrong base URL
 
 - Symptom: request fails immediately, or URL validation/auth endpoint errors.
-- Fix: verify `SN_IMAGE_GEN_BASE_URL`, `SN_CHAT_BASE_URL`, `SN_TEXT_BASE_URL`, and `SN_VISION_BASE_URL` are full base URLs (with scheme + host), for example `https://token.sensenova.cn/v1`.
+- Fix: verify `SN_BASE_URL` or capability-specific base URLs are full base URLs (with scheme + host), for example `https://token.sensenova.cn/v1`.
 
 ### Unsupported model name
 

--- a/skills/sn-image-base/README_CN.md
+++ b/skills/sn-image-base/README_CN.md
@@ -39,11 +39,12 @@
 将以下环境变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
 
 ```ini
-# 图像生成
-SN_IMAGE_GEN_API_KEY="<sensenova-token-plan-api-key>"
+# 如果所有能力都走同一个网关，只需要配置这两个变量。
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="<sensenova-token-plan-api-key>"
+
+# 可选模型覆盖
 SN_IMAGE_GEN_MODEL="sensenova-u1-fast"   # 或 Token Plan 中可用的其他图像生成模型
-# 文本与视觉 Chat Runtime
-SN_CHAT_API_KEY="<sensenova-token-plan-api-key>"
 SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ```
 
@@ -71,18 +72,29 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 
 #### 图像生成
 
+环境变量解析优先级为：专用变量 > 领域共享变量 > 全局变量。
+
+| 能力 | API key fallback | Base URL fallback |
+| ---- | ---------------- | ----------------- |
+| 文本模型 | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
+| 视觉模型 | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
+| 图像生成 | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` |
+
 图像生成完整配置如下：
 
 | 配置键 | 说明 | 默认值 |
 | ------ | ---- | ------ |
-| `SN_IMAGE_GEN_API_KEY` | SenseNova Token Plan 的 API Key | （必填） |
+| `SN_API_KEY` | 所有能力共用的全局 API Key | `""` |
+| `SN_BASE_URL` | 所有能力共用的全局基础 URL | `""` |
+| `SN_IMAGE_GEN_API_KEY` | 可选的图像生成专用 API key 覆盖 | `SN_API_KEY` |
 | `SN_IMAGE_GEN_MODEL_TYPE` | 图像生成模型类型 | `"sensenova"` |
 | `SN_IMAGE_GEN_MODEL` | 图像生成模型名 | `"sensenova-u1-fast"` |
-| `SN_IMAGE_GEN_BASE_URL` | 图像生成 API 的基础 URL | `"https://token.sensenova.cn/v1"` |
+| `SN_IMAGE_GEN_BASE_URL` | 图像生成 API 的基础 URL | `SN_BASE_URL`，然后 `"https://token.sensenova.cn/v1"` |
 
 默认值适用于 [SenseNova](https://platform.sensenova.cn/)。
 
-通常只需设置 `SN_IMAGE_GEN_API_KEY`，并可按需将 `SN_IMAGE_GEN_MODEL` 设置为 token plan 提供的模型名。
+如果所有能力走同一个网关，只需要设置 `SN_BASE_URL` 和 `SN_API_KEY`。
+仅当图像生成需要不同 provider 时，再设置 `SN_IMAGE_GEN_*`。
 
 如需使用非默认图像生成模型，请按以下步骤：
 
@@ -119,7 +131,7 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
     SN_IMAGE_GEN_MODEL="gpt-image-2"
     ```
 
-4. （必填）设置 `SN_IMAGE_GEN_API_KEY` 为图像生成 API 的密钥：
+4. 如果图像生成使用不同于全局 key 的密钥，再设置 `SN_IMAGE_GEN_API_KEY`。如果 `SN_API_KEY` 已可用于图像生成，则无需设置。
 
     ```ini
     SN_IMAGE_GEN_API_KEY="sk-your-image-generation-api-key"
@@ -133,16 +145,16 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 
 | 配置键 | 说明 | 默认值 |
 | ------ | ---- | ------ |
-| `SN_CHAT_API_KEY` | text/vision chat 调用共用 API key | （必填） |
-| `SN_CHAT_BASE_URL` | 共享 Chat API 基础 URL | `"https://token.sensenova.cn/v1"` |
+| `SN_CHAT_API_KEY` | text/vision chat 调用共用 API key | `SN_API_KEY` |
+| `SN_CHAT_BASE_URL` | 共享 Chat API 基础 URL | `SN_BASE_URL`，然后 `"https://token.sensenova.cn/v1"` |
 | `SN_CHAT_TYPE` | 共享 Chat 协议类型 | `"openai-completions"` |
 | `SN_CHAT_MODEL` | text/vision chat 调用共用默认模型 | `"sensenova-6.7-flash-lite"` |
-| `SN_TEXT_API_KEY` | 可选文本 provider API key | `SN_CHAT_API_KEY` |
-| `SN_TEXT_BASE_URL` | 可选文本 provider 基础 URL | `SN_CHAT_BASE_URL` |
+| `SN_TEXT_API_KEY` | 可选文本 provider API key | `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `SN_TEXT_BASE_URL` | 可选文本 provider 基础 URL | `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `SN_TEXT_TYPE` | 可选文本协议类型 | `SN_CHAT_TYPE` |
 | `SN_TEXT_MODEL` | 可选的 `sn-text-optimize` 模型覆盖 | `SN_CHAT_MODEL` |
-| `SN_VISION_API_KEY` | 可选视觉 provider API key | `SN_CHAT_API_KEY` |
-| `SN_VISION_BASE_URL` | 可选视觉 provider 基础 URL | `SN_CHAT_BASE_URL` |
+| `SN_VISION_API_KEY` | 可选视觉 provider API key | `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `SN_VISION_BASE_URL` | 可选视觉 provider 基础 URL | `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `SN_VISION_TYPE` | 可选视觉协议类型 | `SN_CHAT_TYPE` |
 | `SN_VISION_MODEL` | 可选的 `sn-image-recognize` 视觉模型覆盖 | `SN_CHAT_MODEL` |
 
@@ -192,7 +204,7 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
     SN_TEXT_MODEL="gpt-5.5"
     ```
 
-4. （必填）设置 `SN_CHAT_API_KEY` 为共享 chat endpoint 的 API key：
+4. 设置 `SN_CHAT_API_KEY` 为共享 chat endpoint 的 API key，或使用全局 `SN_API_KEY`：
 
     ```ini
     SN_CHAT_API_KEY="sk-your-api-key"
@@ -203,12 +215,12 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ### 缺少 API key
 
 - 现象：报错包含 "required but not set"、"missing api key" 或请求未授权。
-- 处理：图像生成需设置 `SN_IMAGE_GEN_API_KEY`；chat 调用需设置 `SN_CHAT_API_KEY`。如果文本和视觉使用不同 provider，可设置 `SN_TEXT_API_KEY` 或 `SN_VISION_API_KEY`。
+- 处理：如果所有能力使用同一个 key，设置全局 `SN_API_KEY` 即可。不要重复设置 `SN_IMAGE_GEN_API_KEY`，除非图像生成需要不同 provider 或 key；仅当 chat/text/vision 需要不同 provider 时，再设置 `SN_CHAT_API_KEY`、`SN_TEXT_API_KEY` 或 `SN_VISION_API_KEY`。
 
 ### base URL 配置错误
 
 - 现象：请求立即失败，或出现 URL 校验 / endpoint 相关错误。
-- 处理：检查 `SN_IMAGE_GEN_BASE_URL`、`SN_CHAT_BASE_URL`、`SN_TEXT_BASE_URL`、`SN_VISION_BASE_URL` 是否为完整基础 URL（包含 scheme + host），例如 `https://token.sensenova.cn/v1`。
+- 处理：检查 `SN_BASE_URL` 或能力专用 base URL 是否为完整基础 URL（包含 scheme + host），例如 `https://token.sensenova.cn/v1`。
 
 ### 模型名不支持
 

--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -52,8 +52,8 @@ Image generation tool that calls the text-to-image-no-enhance API.
 | `--aspect-ratio` | string | `16:9` | Aspect ratio, e.g. `1:1`, `16:9`, `9:16` |
 | `--seed` | int | `None` | Random seed for reproducible generation |
 | `--unet-name` | string | `None` | Specify a UNet model name |
-| `--api-key` | string | Read from `SN_IMAGE_GEN_API_KEY` env var | API key (CLI argument has priority; `MissingApiKeyError` is raised when both are empty) |
-| `--base-url` | string | Read from `SN_IMAGE_GEN_BASE_URL` env var | API base URL (CLI argument has priority; `MissingApiKeyError` is raised when both are empty) |
+| `--api-key` | string | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | API key (CLI argument has priority; `MissingApiKeyError` is raised when all are empty) |
+| `--base-url` | string | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` | API base URL (CLI argument has priority) |
 | `--poll-interval` | float | `5.0` | Polling interval (seconds) |
 | `--timeout` | float | `300.0` | Timeout (seconds) |
 | `--insecure` | flag | `False` | Disable TLS verification |
@@ -67,8 +67,8 @@ Image recognition tool that uses VLM (Vision Language Model) to analyze image co
 
 | Parameter | Type | Built-in Default | Env Var | Description |
 |------|------|-----------|---------|------|
-| `--api-key` | string | No hardcoded default | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` | Chat runtime API key; raises `MissingApiKeyError` when all are unset |
-| `--base-url` | string | `SN_CHAT_BASE_URL` default | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` | Vision provider base URL; falls back to shared chat provider |
+| `--api-key` | string | No hardcoded default | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | Chat runtime API key; raises `MissingApiKeyError` when all are unset |
+| `--base-url` | string | `SN_CHAT_BASE_URL` default | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` | Vision provider base URL; falls back to shared chat/global provider |
 | `--model` | string | `sensenova-6.7-flash-lite` | `SN_VISION_MODEL` -> `SN_CHAT_MODEL` | Vision-capable model name |
 | `--vlm-type` | string | `openai-completions` | `SN_VISION_TYPE` -> `SN_CHAT_TYPE` | Chat protocol type override |
 | `--user-prompt-path` | string | `None` | - | Local file path, mutually exclusive with `--user-prompt` |
@@ -87,8 +87,8 @@ Text optimization tool that uses LLM (Language Model) to optimize text content. 
 
 | Parameter | Type | Built-in Default | Env Var | Description |
 |------|------|-----------|---------|------|
-| `--api-key` | string | No hardcoded default | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` | Chat runtime API key; raises `MissingApiKeyError` when all are unset |
-| `--base-url` | string | `SN_CHAT_BASE_URL` default | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` | Text provider base URL; falls back to shared chat provider |
+| `--api-key` | string | No hardcoded default | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | Chat runtime API key; raises `MissingApiKeyError` when all are unset |
+| `--base-url` | string | `SN_CHAT_BASE_URL` default | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` | Text provider base URL; falls back to shared chat/global provider |
 | `--model` | string | `sensenova-6.7-flash-lite` | `SN_TEXT_MODEL` -> `SN_CHAT_MODEL` | Text model name |
 | `--llm-type` | string | `openai-completions` | `SN_TEXT_TYPE` -> `SN_CHAT_TYPE` | Chat protocol type override |
 | `--user-prompt-path` | string | `None` | - | Local file path, mutually exclusive with `--user-prompt` |
@@ -158,19 +158,19 @@ Authentication parameters for `sn-image-generate` have the following default beh
 
 | Parameter | Default | Override | Description |
 |------|--------|----------|------|
-| `--base-url` | Read from `SN_IMAGE_GEN_BASE_URL` env var | `--base-url "..."` | CLI argument has priority; throws error if env var and CLI value are both missing |
-| `--api-key` | Read from `SN_IMAGE_GEN_API_KEY` env var | `--api-key "..."` | CLI argument has priority; throws `MissingApiKeyError` if env var and CLI value are both missing |
+| `--base-url` | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` | `--base-url "..."` | CLI argument has priority |
+| `--api-key` | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | `--api-key "..."` | CLI argument has priority; throws `MissingApiKeyError` if all values are empty |
 
-`sn-image-recognize` and `sn-text-optimize` use priority: **CLI argument > command-specific env var > shared `SN_CHAT_*` env var > built-in default**.
+`sn-image-recognize` and `sn-text-optimize` use priority: **CLI argument > command-specific env var > shared `SN_CHAT_*` env var > global `SN_*` env var > built-in default**.
 
 | Parameter | Built-in Default | Vision Env Var | Text Env Var |
 |------|-----------|-------------|-------------|
-| `--api-key` | None (must be provided) | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` |
-| `--base-url` | `https://token.sensenova.cn/v1` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` |
+| `--api-key` | None (must be provided) | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `--base-url` | `https://token.sensenova.cn/v1` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `--model` | `sensenova-6.7-flash-lite` | `SN_VISION_MODEL` -> `SN_CHAT_MODEL` | `SN_TEXT_MODEL` -> `SN_CHAT_MODEL` |
 | `--vlm-type` / `--llm-type` | `openai-completions` | `SN_VISION_TYPE` -> `SN_CHAT_TYPE` | `SN_TEXT_TYPE` -> `SN_CHAT_TYPE` |
 
-`api_key` resolution order (high to low): CLI `--api-key` > command-specific key (`SN_VISION_API_KEY`/`SN_TEXT_API_KEY`) > `SN_CHAT_API_KEY`. If all are unset, `MissingApiKeyError` is raised.
+`api_key` resolution order (high to low): CLI `--api-key` > command-specific key (`SN_VISION_API_KEY`/`SN_TEXT_API_KEY`) > `SN_CHAT_API_KEY` > `SN_API_KEY`. If all are unset, `MissingApiKeyError` is raised.
 
 Only `--api-key` must be provided via CLI or environment; base URL, model, and interface type have shared chat defaults.
 

--- a/skills/sn-image-base/references/api_spec.md
+++ b/skills/sn-image-base/references/api_spec.md
@@ -37,7 +37,8 @@ python sn_agent_runner.py sn-image-generate \
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `--prompt` | string | **Yes** | - | Text prompt |
-| `--api-key` | string | No | Reads `SN_IMAGE_GEN_API_KEY` env var | API Key (CLI takes precedence; raises `MissingApiKeyError` if both are empty) |
+| `--api-key` | string | No | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | API Key (CLI takes precedence; raises `MissingApiKeyError` if all are empty) |
+| `--base-url` | string | No | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` | API base URL (CLI takes precedence) |
 | `--negative-prompt` | string | No | `""` | Negative prompt |
 | `--image-size` | string | No | `"2k"` | Image size: `2k` only |
 | `--aspect-ratio` | string | No | `"16:9"` | Aspect ratio |
@@ -80,18 +81,18 @@ Image generated successfully
 
 ### API Key Notes
 
-`--api-key` is optional. CLI parameter takes precedence; if not provided, reads from `SN_IMAGE_GEN_API_KEY` env var. If both are empty, raises `MissingApiKeyError`:
+`--api-key` is optional. CLI parameter takes precedence; if not provided, reads `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY`. If all are empty, raises `MissingApiKeyError`:
 
 **text format**:
 
 ```
-Error: API key is required but was not provided. Set the SN_IMAGE_GEN_API_KEY environment variable or pass --api-key explicitly.
+Error: API key is required but was not provided. Set SN_API_KEY, or set SN_IMAGE_GEN_API_KEY only for an image-generation-specific override, or pass --api-key explicitly.
 ```
 
 **json format**:
 
 ```json
-{"status": "failed", "error": "API key is required but was not provided. Set the SN_IMAGE_GEN_API_KEY environment variable or pass --api-key explicitly.", "elapsed_seconds": 0.05}
+{"status": "failed", "error": "API key is required but was not provided. Set SN_API_KEY, or set SN_IMAGE_GEN_API_KEY only for an image-generation-specific override, or pass --api-key explicitly.", "elapsed_seconds": 0.05}
 ```
 
 ---
@@ -122,8 +123,8 @@ python sn_agent_runner.py sn-image-recognize \
 | `--user-prompt` | string | One of two | - | User instruction (mutually exclusive with `--user-prompt-path`) |
 | `--user-prompt-path` | path | One of two | - | Local file path to read user instruction from (mutually exclusive with `--user-prompt`) |
 | `--images` | string[] | **Yes** | - | List of image paths (supports multiple) |
-| `--api-key` | string | No | No hardcoded default | CLI > `SN_VISION_API_KEY` > `SN_CHAT_API_KEY`; raises `MissingApiKeyError` if all are empty |
-| `--base-url` | string | No | `https://token.sensenova.cn/v1` | CLI > `SN_VISION_BASE_URL` > `SN_CHAT_BASE_URL` |
+| `--api-key` | string | No | No hardcoded default | CLI > `SN_VISION_API_KEY` > `SN_CHAT_API_KEY` > `SN_API_KEY`; raises `MissingApiKeyError` if all are empty |
+| `--base-url` | string | No | `https://token.sensenova.cn/v1` | CLI > `SN_VISION_BASE_URL` > `SN_CHAT_BASE_URL` > `SN_BASE_URL` |
 | `--model` | string | No | `sensenova-6.7-flash-lite` | CLI > `SN_VISION_MODEL` > `SN_CHAT_MODEL` |
 | `--system-prompt` | string | No | `""` | System instruction (mutually exclusive with `--system-prompt-path`) |
 | `--system-prompt-path` | path | No | - | Local file path to read system instruction from (mutually exclusive with `--system-prompt`) |
@@ -158,12 +159,12 @@ This image shows an adorable orange cat napping in the sunlight.
 
 ### Parameter Priority
 
-`--api-key`, `--base-url`, `--model`, and `--vlm-type` use priority: **CLI parameter > command-specific environment variable > shared `SN_CHAT_*` environment variable > built-in default**.
+`--api-key`, `--base-url`, `--model`, and `--vlm-type` use priority: **CLI parameter > command-specific environment variable > shared `SN_CHAT_*` environment variable > global `SN_*` environment variable > built-in default**.
 
 | Parameter | Built-in Default | Environment Variable |
 |-----------|-----------------|---------------------|
-| `--api-key` | None (required) | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` |
-| `--base-url` | `https://token.sensenova.cn/v1` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` |
+| `--api-key` | None (required) | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `--base-url` | `https://token.sensenova.cn/v1` | `SN_VISION_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `--model` | `sensenova-6.7-flash-lite` | `SN_VISION_MODEL` -> `SN_CHAT_MODEL` |
 | `--vlm-type` | `openai-completions` | `SN_VISION_TYPE` -> `SN_CHAT_TYPE` |
 
@@ -198,8 +199,8 @@ python sn_agent_runner.py sn-text-optimize \
 |-----------|------|----------|---------|-------------|
 | `--user-prompt` | string | One of two | - | User instruction (mutually exclusive with `--user-prompt-path`) |
 | `--user-prompt-path` | path | One of two | - | Local file path to read user instruction from (mutually exclusive with `--user-prompt`) |
-| `--api-key` | string | No | No hardcoded default | CLI > `SN_TEXT_API_KEY` > `SN_CHAT_API_KEY`; raises `MissingApiKeyError` if all are empty |
-| `--base-url` | string | No | `https://token.sensenova.cn/v1` | CLI > `SN_TEXT_BASE_URL` > `SN_CHAT_BASE_URL` |
+| `--api-key` | string | No | No hardcoded default | CLI > `SN_TEXT_API_KEY` > `SN_CHAT_API_KEY` > `SN_API_KEY`; raises `MissingApiKeyError` if all are empty |
+| `--base-url` | string | No | `https://token.sensenova.cn/v1` | CLI > `SN_TEXT_BASE_URL` > `SN_CHAT_BASE_URL` > `SN_BASE_URL` |
 | `--model` | string | No | `sensenova-6.7-flash-lite` | CLI > `SN_TEXT_MODEL` > `SN_CHAT_MODEL` |
 | `--system-prompt` | string | No | `""` | System instruction (mutually exclusive with `--system-prompt-path`) |
 | `--system-prompt-path` | path | No | - | Local file path to read system instruction from (mutually exclusive with `--system-prompt`) |
@@ -234,12 +235,12 @@ Optimized text content...
 
 ### Parameter Priority
 
-`--api-key`, `--base-url`, `--model`, and `--llm-type` use priority: **CLI parameter > command-specific environment variable > shared `SN_CHAT_*` environment variable > built-in default**.
+`--api-key`, `--base-url`, `--model`, and `--llm-type` use priority: **CLI parameter > command-specific environment variable > shared `SN_CHAT_*` environment variable > global `SN_*` environment variable > built-in default**.
 
 | Parameter | Built-in Default | Environment Variable |
 |-----------|-----------------|---------------------|
-| `--api-key` | None (required) | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` |
-| `--base-url` | `https://token.sensenova.cn/v1` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` |
+| `--api-key` | None (required) | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` |
+| `--base-url` | `https://token.sensenova.cn/v1` | `SN_TEXT_BASE_URL` -> `SN_CHAT_BASE_URL` -> `SN_BASE_URL` |
 | `--model` | `sensenova-6.7-flash-lite` | `SN_TEXT_MODEL` -> `SN_CHAT_MODEL` |
 | `--llm-type` | `openai-completions` | `SN_TEXT_TYPE` -> `SN_CHAT_TYPE` |
 
@@ -283,8 +284,8 @@ Error messages are written to stderr and do not affect stdout content.
 
 | Tool | Environment Variables (high → low priority) | Notes |
 |------|---------------------------------------------|-------|
-| `sn-image-generate` | `SN_IMAGE_GEN_API_KEY` | CLI takes precedence; reads this var if not provided; raises `MissingApiKeyError` if both are empty |
-| `sn-image-recognize` | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` | CLI > command-specific key > shared chat key; raises `MissingApiKeyError` if all are empty |
-| `sn-text-optimize` | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` | CLI > command-specific key > shared chat key; raises `MissingApiKeyError` if all are empty |
+| `sn-image-generate` | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | CLI > optional image generation key > global key; raises `MissingApiKeyError` if all are empty |
+| `sn-image-recognize` | `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | CLI > command-specific key > shared chat key > global key; raises `MissingApiKeyError` if all are empty |
+| `sn-text-optimize` | `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | CLI > command-specific key > shared chat key > global key; raises `MissingApiKeyError` if all are empty |
 
-`SN_CHAT_API_KEY` is the shared key for both text and vision chat calls. Use `SN_TEXT_API_KEY` or `SN_VISION_API_KEY` when a command needs a different provider.
+`SN_API_KEY` is the global key for all capabilities. `SN_CHAT_API_KEY` is the shared key for both text and vision chat calls. Use command-specific keys only when a command needs a different provider.

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -103,12 +103,14 @@ def build_parser() -> argparse.ArgumentParser:
     gen_parser.add_argument("--seed", type=int, default=None, help="Random seed")
     gen_parser.add_argument("--unet-name", dest="unet_name", default=None, help="UNet model name")
     gen_parser.add_argument(
-        "--api-key", default="", help="API key (falls back to SN_IMAGE_GEN_API_KEY env var)"
+        "--api-key",
+        default="",
+        help="API key (CLI > SN_IMAGE_GEN_API_KEY > SN_API_KEY)",
     )
     gen_parser.add_argument(
         "--base-url",
         default="",
-        help="API base URL (falls back to SN_IMAGE_GEN_BASE_URL env var)",
+        help="API base URL (CLI > SN_IMAGE_GEN_BASE_URL > SN_BASE_URL)",
     )
     gen_parser.add_argument("--poll-interval", type=float, default=5.0)
     gen_parser.add_argument("--timeout", type=float, default=300.0)
@@ -134,12 +136,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     recog_parser.add_argument("--images", required=True, nargs="+", help="Image file paths or URLs")
     recog_parser.add_argument(
-        "--api-key", default=None, help="API key (CLI > SN_VISION_API_KEY > SN_CHAT_API_KEY)"
+        "--api-key",
+        default=None,
+        help="API key (CLI > SN_VISION_API_KEY > SN_CHAT_API_KEY > SN_API_KEY)",
     )
     recog_parser.add_argument(
         "--base-url",
         default=None,
-        help="API base URL (CLI > SN_VISION_BASE_URL > SN_CHAT_BASE_URL)",
+        help="API base URL (CLI > SN_VISION_BASE_URL > SN_CHAT_BASE_URL > SN_BASE_URL)",
     )
     recog_parser.add_argument(
         "--model",
@@ -169,12 +173,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a local file containing the system prompt (mutually exclusive with --system-prompt)",
     )
     opt_parser.add_argument(
-        "--api-key", default=None, help="API key (CLI > SN_TEXT_API_KEY > SN_CHAT_API_KEY)"
+        "--api-key",
+        default=None,
+        help="API key (CLI > SN_TEXT_API_KEY > SN_CHAT_API_KEY > SN_API_KEY)",
     )
     opt_parser.add_argument(
         "--base-url",
         default=None,
-        help="API base URL (CLI > SN_TEXT_BASE_URL > SN_CHAT_BASE_URL)",
+        help="API base URL (CLI > SN_TEXT_BASE_URL > SN_CHAT_BASE_URL > SN_BASE_URL)",
     )
     opt_parser.add_argument(
         "--model",
@@ -206,12 +212,14 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
     """
     api_key = args.api_key or global_configs.SN_IMAGE_GEN_API_KEY
     if not api_key:
-        raise MissingApiKeyError()
+        raise MissingApiKeyError(global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY"))
 
     base_url = args.base_url or global_configs.SN_IMAGE_GEN_BASE_URL
     if not base_url:
         raise InvalidBaseUrlError(
-            "No base URL provided. Set SN_IMAGE_GEN_BASE_URL env var or pass --base-url."
+            "No base URL provided. "
+            f"{global_configs.get_env_var_help('SN_IMAGE_GEN_BASE_URL')} "
+            "Or pass --base-url."
         )
 
     if global_configs.SN_IMAGE_GEN_MODEL_TYPE == "sensenova":
@@ -372,8 +380,8 @@ RUNTIME_PROFILES = {
         "model_config": "SN_VISION_MODEL",
         "api_key_config": "SN_VISION_API_KEY",
         "label": "vision",
-        "key_env": "SN_VISION_API_KEY or SN_CHAT_API_KEY",
-        "url_env": "SN_VISION_BASE_URL or SN_CHAT_BASE_URL",
+        "key_env": "SN_VISION_API_KEY, SN_CHAT_API_KEY, or SN_API_KEY",
+        "url_env": "SN_VISION_BASE_URL, SN_CHAT_BASE_URL, or SN_BASE_URL",
         "model_env": "SN_VISION_MODEL or SN_CHAT_MODEL",
         "type_env": "SN_VISION_TYPE or SN_CHAT_TYPE",
     },
@@ -384,8 +392,8 @@ RUNTIME_PROFILES = {
         "model_config": "SN_TEXT_MODEL",
         "api_key_config": "SN_TEXT_API_KEY",
         "label": "text",
-        "key_env": "SN_TEXT_API_KEY or SN_CHAT_API_KEY",
-        "url_env": "SN_TEXT_BASE_URL or SN_CHAT_BASE_URL",
+        "key_env": "SN_TEXT_API_KEY, SN_CHAT_API_KEY, or SN_API_KEY",
+        "url_env": "SN_TEXT_BASE_URL, SN_CHAT_BASE_URL, or SN_BASE_URL",
         "model_env": "SN_TEXT_MODEL or SN_CHAT_MODEL",
         "type_env": "SN_TEXT_TYPE or SN_CHAT_TYPE",
     },

--- a/skills/sn-image-base/scripts/sn_image_base/configs.py
+++ b/skills/sn-image-base/scripts/sn_image_base/configs.py
@@ -86,12 +86,16 @@ class Configs:
     default is kept.
     """
 
+    # global defaults shared by all SN capabilities.
+    SN_API_KEY: Annotated[str, Field("SN_API_KEY", secret=True)] = ""
+    SN_BASE_URL: Annotated[str, Field("SN_BASE_URL")] = ""
+
     # image-generate
     SN_IMAGE_GEN_API_KEY: Annotated[
-        str, Field("SN_IMAGE_GEN_API_KEY", required=True, secret=True)
+        str, Field("SN_IMAGE_GEN_API_KEY", "SN_API_KEY", required=True, secret=True)
     ] = ""
     SN_IMAGE_GEN_BASE_URL: Annotated[
-        str, Field("SN_IMAGE_GEN_BASE_URL", required=True)
+        str, Field("SN_IMAGE_GEN_BASE_URL", "SN_BASE_URL", required=True)
     ] = "https://token.sensenova.cn/v1"
     SN_IMAGE_GEN_MODEL_TYPE: Annotated[
         Literal["sensenova", "nano-banana", "openai-image"], Field("SN_IMAGE_GEN_MODEL_TYPE")
@@ -100,16 +104,20 @@ class Configs:
 
     # chat runtime shared by text and vision commands; command-specific
     # SN_TEXT_* / SN_VISION_* values override these defaults.
-    SN_CHAT_API_KEY: Annotated[str, Field("SN_CHAT_API_KEY", secret=True)] = ""
-    SN_CHAT_BASE_URL: Annotated[str, Field("SN_CHAT_BASE_URL")] = (
+    SN_CHAT_API_KEY: Annotated[str, Field("SN_CHAT_API_KEY", "SN_API_KEY", secret=True)] = ""
+    SN_CHAT_BASE_URL: Annotated[str, Field("SN_CHAT_BASE_URL", "SN_BASE_URL")] = (
         "https://token.sensenova.cn/v1"
     )
     SN_CHAT_TYPE: Annotated[
         Literal["anthropic-messages", "openai-completions"], Field("SN_CHAT_TYPE")
     ] = "openai-completions"
     SN_CHAT_MODEL: Annotated[str, Field("SN_CHAT_MODEL")] = "sensenova-6.7-flash-lite"
-    SN_TEXT_API_KEY: Annotated[str, Field("SN_TEXT_API_KEY", "SN_CHAT_API_KEY", secret=True)] = ""
-    SN_TEXT_BASE_URL: Annotated[str, Field("SN_TEXT_BASE_URL", "SN_CHAT_BASE_URL")] = ""
+    SN_TEXT_API_KEY: Annotated[
+        str, Field("SN_TEXT_API_KEY", "SN_CHAT_API_KEY", "SN_API_KEY", secret=True)
+    ] = ""
+    SN_TEXT_BASE_URL: Annotated[
+        str, Field("SN_TEXT_BASE_URL", "SN_CHAT_BASE_URL", "SN_BASE_URL")
+    ] = ""
     SN_TEXT_TYPE: Annotated[
         Literal["anthropic-messages", "openai-completions"],
         Field("SN_TEXT_TYPE", "SN_CHAT_TYPE"),
@@ -117,8 +125,12 @@ class Configs:
     SN_TEXT_MODEL: Annotated[str, Field("SN_TEXT_MODEL", "SN_CHAT_MODEL")] = (
         "sensenova-6.7-flash-lite"
     )
-    SN_VISION_API_KEY: Annotated[str, Field("SN_VISION_API_KEY", "SN_CHAT_API_KEY", secret=True)] = ""
-    SN_VISION_BASE_URL: Annotated[str, Field("SN_VISION_BASE_URL", "SN_CHAT_BASE_URL")] = ""
+    SN_VISION_API_KEY: Annotated[
+        str, Field("SN_VISION_API_KEY", "SN_CHAT_API_KEY", "SN_API_KEY", secret=True)
+    ] = ""
+    SN_VISION_BASE_URL: Annotated[
+        str, Field("SN_VISION_BASE_URL", "SN_CHAT_BASE_URL", "SN_BASE_URL")
+    ] = ""
     SN_VISION_TYPE: Annotated[
         Literal["anthropic-messages", "openai-completions"],
         Field("SN_VISION_TYPE", "SN_CHAT_TYPE"),
@@ -169,7 +181,13 @@ class Configs:
             value = getattr(self, field_name, None)
             if not value:
                 if field.required:
-                    msg = f"Field '{field_name}' is required but not set; try setting the environment variable(s) {field.env_names}"
+                    if field_name == "SN_IMAGE_GEN_API_KEY":
+                        msg = (
+                            "Image generation API key is not set; configure SN_API_KEY, "
+                            "or configure SN_IMAGE_GEN_API_KEY only for an image-generation-specific override"
+                        )
+                    else:
+                        msg = f"Field '{field_name}' is required but not set; try setting the environment variable(s) {field.env_names}"
                     errors.append((field_name, msg))
                 continue
 
@@ -183,15 +201,15 @@ class Configs:
         warnings: list[tuple[str, str]] = []
         runtime_checks = {
             "text": {
-                "api_key": ("SN_TEXT_API_KEY", "SN_CHAT_API_KEY"),
+                "api_key": ("SN_TEXT_API_KEY",),
                 "base_url": ("SN_TEXT_BASE_URL", "SN_CHAT_BASE_URL"),
-                "model": ("SN_TEXT_MODEL", "SN_CHAT_MODEL"),
+                "model": ("SN_TEXT_MODEL",),
                 "type": ("SN_TEXT_TYPE", "SN_CHAT_TYPE"),
             },
             "vision": {
-                "api_key": ("SN_VISION_API_KEY", "SN_CHAT_API_KEY"),
+                "api_key": ("SN_VISION_API_KEY",),
                 "base_url": ("SN_VISION_BASE_URL", "SN_CHAT_BASE_URL"),
-                "model": ("SN_VISION_MODEL", "SN_CHAT_MODEL"),
+                "model": ("SN_VISION_MODEL",),
                 "type": ("SN_VISION_TYPE", "SN_CHAT_TYPE"),
             },
         }
@@ -217,6 +235,17 @@ class Configs:
                 f"{key} is not a valid base URL: {getattr(self, key)}",
             )
             for key in ("SN_CHAT_BASE_URL", "SN_TEXT_BASE_URL", "SN_VISION_BASE_URL")
+            if getattr(self, key) and not is_valid_base_url(getattr(self, key))
+        )
+        errors.extend(
+            (
+                key,
+                f"{key} is not a valid base URL: {getattr(self, key)}",
+            )
+            for key in (
+                "SN_BASE_URL",
+                "SN_IMAGE_GEN_BASE_URL",
+            )
             if getattr(self, key) and not is_valid_base_url(getattr(self, key))
         )
         return errors, warnings

--- a/skills/sn-image-base/scripts/sn_image_base/exceptions.py
+++ b/skills/sn-image-base/scripts/sn_image_base/exceptions.py
@@ -25,7 +25,8 @@ class MissingApiKeyError(BadConfigurationError):
 
     DEFAULT_MESSAGE = (
         "API key is required but was not provided. "
-        "Set the SN_IMAGE_GEN_API_KEY environment variable or pass --api-key explicitly."
+        "Set SN_API_KEY, or set SN_IMAGE_GEN_API_KEY only for an image-generation-specific "
+        "override, or pass --api-key explicitly."
     )
 
 
@@ -34,5 +35,5 @@ class InvalidBaseUrlError(BadConfigurationError):
 
     DEFAULT_MESSAGE = (
         "Base URL is required but was not provided. "
-        "Set the SN_IMAGE_GEN_BASE_URL environment variable or pass --base-url explicitly."
+        "Set SN_IMAGE_GEN_BASE_URL or SN_BASE_URL, or pass --base-url explicitly."
     )

--- a/skills/sn-image-doctor/SKILL.md
+++ b/skills/sn-image-doctor/SKILL.md
@@ -60,15 +60,15 @@ python scripts/check_environment.py --verbose
   ✅ All required packages installed
 
 [3/3] Checking environment variables...
-  ❌ SN_IMAGE_GEN_API_KEY not set (required)
+  ❌ SN_IMAGE_GEN_API_KEY: Image generation API key is not set; configure SN_API_KEY, or configure SN_IMAGE_GEN_API_KEY only for an image-generation-specific override
 
   Some required environment variables are missing.
   Enter values below to save them to /path/to/.env.
   Press Enter to skip a variable.
 
-  SN_IMAGE_GEN_API_KEY: <user input>
+  SN_API_KEY: <user input>
 
-  ✅ Saved to /path/to/.env: SN_IMAGE_GEN_API_KEY
+  ✅ Saved to /path/to/.env: SN_API_KEY
   🔄 Reloading environment...
   ✅ Environment reloaded successfully
 
@@ -79,7 +79,7 @@ python scripts/check_environment.py --verbose
 If reload fails, the output will suggest restarting the agent:
 
 ```
-  ✅ Saved to /path/to/.env: SN_IMAGE_GEN_API_KEY
+  ✅ Saved to /path/to/.env: SN_API_KEY
   🔄 Reloading environment...
   ⚠️  Failed to reload environment: <error message>
   💡 Suggestion: Restart the agent to apply new configuration
@@ -144,16 +144,14 @@ pip install -r skills/sn-image-base/requirements.txt
 **Solution:**
 
 ```bash
-# Set environment variables in your shell
-export SN_IMAGE_GEN_API_KEY="your-api-key"
-export SN_IMAGE_GEN_BASE_URL="https://your-api-endpoint.com"
+# If all capabilities use the same gateway, set only the global values.
+export SN_API_KEY="your-api-key"
+export SN_BASE_URL="https://your-api-endpoint.com"
 
 # Or create a .env file
 cat > .env << EOF
-SN_IMAGE_GEN_API_KEY=your-api-key
-SN_IMAGE_GEN_BASE_URL=https://token.sensenova.cn/v1
-SN_CHAT_API_KEY=your-chat-api-key
-SN_CHAT_BASE_URL=https://token.sensenova.cn/v1
+SN_API_KEY=your-api-key
+SN_BASE_URL=https://token.sensenova.cn/v1
 SN_CHAT_TYPE=openai-completions
 SN_CHAT_MODEL=sensenova-6.7-flash-lite
 EOF
@@ -161,6 +159,8 @@ EOF
 # Load .env file
 source .env  # Or use a tool like python-dotenv
 ```
+
+Fallback priority is capability-specific variable > domain shared variable > global variable. For example, text calls use `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY`; vision calls use `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY`; image generation uses `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY`.
 
 ### API Connectivity Issues
 

--- a/skills/sn-image-doctor/scripts/check_environment.py
+++ b/skills/sn-image-doctor/scripts/check_environment.py
@@ -13,9 +13,9 @@ Checks performed:
    - All packages in sn-image-base/requirements.txt are installed
 
 3. Environment variables
-   Driven by sn_image_base.configs.Configs. Image generation uses SN_IMAGE_GEN_API_KEY,
-   while text/vision chat calls use SN_CHAT_* with optional SN_TEXT_* and
-   SN_VISION_* provider overrides.
+   Driven by sn_image_base.configs.Configs. The minimal shared-gateway setup is
+   SN_BASE_URL + SN_API_KEY. Capability-specific variables override shared and
+   global values when present.
 """
 
 import argparse

--- a/skills/sn-image-imitate/README.md
+++ b/skills/sn-image-imitate/README.md
@@ -7,7 +7,7 @@ This document introduces the `sn-image-imitate` skill and provides a Quick Start
 ## Prerequisites
 
 - **Python** 3.9 or later (3.10+ recommended).
-- **SN API** credentials for image generation and LLM/VLM endpoints (`SN_IMAGE_BASE_API_KEY`, `SN_CHAT_API_KEY`; see Quick Start).
+- **SN API** credentials for image generation and LLM/VLM endpoints (`SN_API_KEY` and `SN_BASE_URL` are enough when all capabilities use one gateway; see Quick Start).
 - `sn-image-base` skill installed (as a base dependency).
 
 ## Skill Overview
@@ -58,9 +58,11 @@ Dependency installation and API key configuration are for [sn-image-base](../sn-
 The minimum environment variables to configure `sn-image-base` skill running with [SenseNova Token Plan](https://platform.sensenova.cn/token-plan):
 
 ```ini
-SN_IMAGE_GEN_API_KEY="your-api-key"
-SN_CHAT_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="your-api-key"
 ```
+
+Use capability-specific variables only when a provider differs from the shared gateway: `SN_TEXT_*`, `SN_VISION_*`, `SN_CHAT_*`, or `SN_IMAGE_GEN_*`.
 
 Please refer to the **Python dependencies and API keys** section in [`sn-image-generate_en.md`](../../docs/sn-image-generate_en.md) for more configurations.
 

--- a/skills/sn-image-imitate/README_CN.md
+++ b/skills/sn-image-imitate/README_CN.md
@@ -7,7 +7,7 @@
 ## 环境要求
 
 - **Python** 3.9 或更高版本（推荐 3.10+）。
-- **SN API** 凭据，用于图像生成与 LLM/VLM 接口（`SN_IMAGE_BASE_API_KEY`、`SN_CHAT_API_KEY`，详见 Quick Start）。
+- **SN API** 凭据，用于图像生成与 LLM/VLM 接口（所有能力共用同一网关时，`SN_API_KEY` 和 `SN_BASE_URL` 即可；详见 Quick Start）。
 - 已安装 `sn-image-base` 技能（作为底层依赖）。
 
 ## 技能介绍
@@ -58,9 +58,11 @@ sn-image-base (Tier 0)
 使用 [SenseNova Token Plan](https://platform.sensenova.cn/token-plan) 运行 `sn-image-base` 技能所需的最小环境变量：
 
 ```ini
-SN_IMAGE_GEN_API_KEY="your-api-key"
-SN_CHAT_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="your-api-key"
 ```
+
+仅当某个能力需要不同 provider 时，再设置能力专用变量：`SN_TEXT_*`、`SN_VISION_*`、`SN_CHAT_*` 或 `SN_IMAGE_GEN_*`。
 
 更多配置请参考 [`sn-image-generate.md`](../../docs/sn-image-generate.md) 中的 **Python 依赖与 API Key** 段落。
 

--- a/skills/sn-image-imitate/SKILL.md
+++ b/skills/sn-image-imitate/SKILL.md
@@ -59,9 +59,11 @@ Dependency installation and API key configuration are for [sn-image-base](../sn-
 The minimum environment variables to configure `sn-image-base` skill running with [SenseNova Token Plan](https://platform.sensenova.cn/token-plan):
 
 ```ini
-SN_IMAGE_GEN_API_KEY="your-api-key"
-SN_CHAT_API_KEY="your-api-key"
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="your-api-key"
 ```
+
+Fallback priority is dedicated variable > domain shared variable > global variable. Text calls use `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY`; vision calls use `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY`; image generation uses `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY`.
 
 Please refer to the **Python dependencies and API keys** section in [`sn-image-generate_en.md`](../../docs/sn-image-generate_en.md) for more configurations.
 

--- a/skills/sn-image-resume/SKILL.md
+++ b/skills/sn-image-resume/SKILL.md
@@ -58,8 +58,15 @@ All API calls in this skill are executed through the `sn_agent_runner.py` of the
 
 |Call Type|Tool|Authentication Parameters|Description|
 |---|---|---|---|
-|**LLM**|`sn-text-optimize`|Default reads `SN_TEXT_API_KEY` / `SN_CHAT_API_KEY` environment variables|Converts user resume text into a detailed image generation prompt using `prompts/resume.md` as the system prompt|
-|**Image Generation**|`sn-image-generate`|Default reads `SN_IMAGE_GEN_API_KEY` environment variable|Generates the final resume image|
+|**LLM**|`sn-text-optimize`|Default reads `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY`|Converts user resume text into a detailed image generation prompt using `prompts/resume.md` as the system prompt|
+|**Image Generation**|`sn-image-generate`|Default reads `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY`|Generates the final resume image|
+
+If all capabilities use the same gateway, configure only:
+
+```ini
+SN_BASE_URL="https://your-api-endpoint.com/v1"
+SN_API_KEY="your-api-key"
+```
 
 **When encountering `MissingApiKeyError` or needing to specify a model**: pass parameters explicitly via CLI. See `$SN_IMAGE_BASE/references/api_spec.md`.
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -53,9 +53,9 @@ All API calls in this skill are executed through the `sn_agent_runner.py` of the
 
 | Call Type | Tool | Authentication Parameters | Description |
 |-----------|------|---------------------------|-------------|
-| **LLM** | sn-text-optimize (evaluation/expansion) | Default reads `SN_TEXT_API_KEY` / `SN_CHAT_API_KEY` environment variables | Built-in default points to Sensenova internal network service |
-| **VLM** | sn-image-recognize (image review) | Default reads `SN_VISION_API_KEY` / `SN_CHAT_API_KEY` environment variables | Built-in default points to Sensenova internal network service |
-| **Image Generation** | sn-image-generate | Default reads `SN_IMAGE_GEN_API_KEY` environment variable | Default uses image generation configuration of `sn-image-base` |
+| **LLM** | sn-text-optimize (evaluation/expansion) | Default reads `SN_TEXT_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | Built-in default points to Sensenova internal network service |
+| **VLM** | sn-image-recognize (image review) | Default reads `SN_VISION_API_KEY` -> `SN_CHAT_API_KEY` -> `SN_API_KEY` | Built-in default points to Sensenova internal network service |
+| **Image Generation** | sn-image-generate | Default reads `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY`; `SN_IMAGE_GEN_API_KEY` is only needed for image-specific override | Default uses image generation configuration of `sn-image-base` |
 
 **When encountering `MissingApiKeyError` or needing to specify a model**: pass explicitly via CLI parameters, parameter reference `$SN_IMAGE_BASE/references/api_spec.md`.
 

--- a/skills/sn-ppt-doctor/SKILL.md
+++ b/skills/sn-ppt-doctor/SKILL.md
@@ -24,9 +24,9 @@ triggers:
 
 ## Hard checks (must pass before sn-ppt-entry can run)
 
-1. Text chat API key is available via `SN_TEXT_API_KEY` or shared `SN_CHAT_API_KEY`
-2. Vision chat API key is available via `SN_VISION_API_KEY` or shared `SN_CHAT_API_KEY`
-3. `SN_IMAGE_GEN_API_KEY` is set
+1. Text chat API key is available via `SN_TEXT_API_KEY`, shared `SN_CHAT_API_KEY`, or global `SN_API_KEY`
+2. Vision chat API key is available via `SN_VISION_API_KEY`, shared `SN_CHAT_API_KEY`, or global `SN_API_KEY`
+3. Image generation API key is available via `SN_IMAGE_GEN_API_KEY` or global `SN_API_KEY`
 4. `sn-image-base` is discoverable and `sn_agent_runner.py --help` works (auto-resolved as a sibling skill under the same `skills/` directory; `SN_IMAGE_BASE` only needed for non-standard layouts)
 5. `node --version` >= 18
 

--- a/skills/sn-ppt-doctor/ppt_doctor/check_environment.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/check_environment.py
@@ -10,7 +10,8 @@ self-contained design so OpenClaw can invoke it via a plain file path.
 
 Sections:
     1. CheckResult dataclass + shared helpers
-    2. Hard checks   (SN_CHAT_API_KEY or SN_TEXT/SN_VISION API keys, SN_IMAGE_GEN_API_KEY,
+    2. Hard checks   (SN_API_KEY or SN_CHAT/SN_TEXT/SN_VISION API keys,
+                      SN_API_KEY or SN_IMAGE_GEN_API_KEY,
                       SN_IMAGE_BASE discovery, sn_agent_runner executable,
                       Node >= 18)
     3. Soft checks   (PPT_DECK_ROOT writable, optional env vars,
@@ -120,32 +121,32 @@ def _find_sn_agent_runner() -> Path | None:
 
 
 def check_text_chat_api_key() -> CheckResult:
-    val = _first_env("SN_TEXT_API_KEY", "SN_CHAT_API_KEY")
+    val = _first_env("SN_TEXT_API_KEY", "SN_CHAT_API_KEY", "SN_API_KEY")
     return CheckResult(
-        name="SN_TEXT_API_KEY / SN_CHAT_API_KEY",
+        name="SN_TEXT_API_KEY / SN_CHAT_API_KEY / SN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_TEXT_API_KEY or SN_CHAT_API_KEY is required for text chat calls; set it or run /skill sn-ppt-doctor to configure interactively",
+        detail="set" if val else "SN_API_KEY is required for text chat calls unless SN_TEXT_API_KEY or SN_CHAT_API_KEY is set; set it or run /skill sn-ppt-doctor to configure interactively",
     )
 
 
 def check_vision_chat_api_key() -> CheckResult:
-    val = _first_env("SN_VISION_API_KEY", "SN_CHAT_API_KEY")
+    val = _first_env("SN_VISION_API_KEY", "SN_CHAT_API_KEY", "SN_API_KEY")
     return CheckResult(
-        name="SN_VISION_API_KEY / SN_CHAT_API_KEY",
+        name="SN_VISION_API_KEY / SN_CHAT_API_KEY / SN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_VISION_API_KEY or SN_CHAT_API_KEY is required for vision chat calls; set it or run /skill sn-ppt-doctor to configure interactively",
+        detail="set" if val else "SN_API_KEY is required for vision chat calls unless SN_VISION_API_KEY or SN_CHAT_API_KEY is set; set it or run /skill sn-ppt-doctor to configure interactively",
     )
 
 
 def check_u1_api_key() -> CheckResult:
-    val = _env("SN_IMAGE_GEN_API_KEY")
+    val = _first_env("SN_IMAGE_GEN_API_KEY", "SN_API_KEY")
     return CheckResult(
-        name="SN_IMAGE_GEN_API_KEY",
+        name="SN_IMAGE_GEN_API_KEY / SN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_IMAGE_GEN_API_KEY is required for image generation calls",
+        detail="set" if val else "SN_API_KEY is required for image generation calls unless SN_IMAGE_GEN_API_KEY is set",
     )
 
 
@@ -412,8 +413,7 @@ def run_all_checks() -> list[CheckResult]:
 
 
 REQUIRED = [
-    ("SN_CHAT_API_KEY", "shared text/vision chat API key"),
-    ("SN_IMAGE_GEN_API_KEY", "Image generation API key"),
+    ("SN_API_KEY", "global SN API key for text, vision, and image generation"),
 ]
 
 

--- a/skills/sn-ppt-doctor/ppt_doctor/checks.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/checks.py
@@ -84,32 +84,32 @@ def _find_sn_agent_runner() -> Path | None:
 # ---------------------------------------------------------------------------
 
 def check_text_chat_api_key() -> CheckResult:
-    val = _first_env("SN_TEXT_API_KEY", "SN_CHAT_API_KEY")
+    val = _first_env("SN_TEXT_API_KEY", "SN_CHAT_API_KEY", "SN_API_KEY")
     return CheckResult(
-        name="SN_TEXT_API_KEY / SN_CHAT_API_KEY",
+        name="SN_TEXT_API_KEY / SN_CHAT_API_KEY / SN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_TEXT_API_KEY or SN_CHAT_API_KEY is required for text chat calls; set it or run /skill sn-ppt-doctor to configure interactively",
+        detail="set" if val else "SN_API_KEY is required for text chat calls unless SN_TEXT_API_KEY or SN_CHAT_API_KEY is set; set it or run /skill sn-ppt-doctor to configure interactively",
     )
 
 
 def check_vision_chat_api_key() -> CheckResult:
-    val = _first_env("SN_VISION_API_KEY", "SN_CHAT_API_KEY")
+    val = _first_env("SN_VISION_API_KEY", "SN_CHAT_API_KEY", "SN_API_KEY")
     return CheckResult(
-        name="SN_VISION_API_KEY / SN_CHAT_API_KEY",
+        name="SN_VISION_API_KEY / SN_CHAT_API_KEY / SN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_VISION_API_KEY or SN_CHAT_API_KEY is required for vision chat calls; set it or run /skill sn-ppt-doctor to configure interactively",
+        detail="set" if val else "SN_API_KEY is required for vision chat calls unless SN_VISION_API_KEY or SN_CHAT_API_KEY is set; set it or run /skill sn-ppt-doctor to configure interactively",
     )
 
 
 def check_u1_api_key() -> CheckResult:
-    val = _env("SN_IMAGE_GEN_API_KEY")
+    val = _first_env("SN_IMAGE_GEN_API_KEY", "SN_API_KEY")
     return CheckResult(
-        name="SN_IMAGE_GEN_API_KEY",
+        name="SN_IMAGE_GEN_API_KEY / SN_API_KEY",
         severity="hard",
         passed=val is not None,
-        detail="set" if val else "SN_IMAGE_GEN_API_KEY is required for image generation calls",
+        detail="set" if val else "SN_API_KEY is required for image generation calls unless SN_IMAGE_GEN_API_KEY is set",
     )
 
 

--- a/skills/sn-ppt-doctor/ppt_doctor/interactive.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/interactive.py
@@ -9,8 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 REQUIRED = [
-    ("SN_CHAT_API_KEY", "shared text/vision chat API key"),
-    ("SN_IMAGE_GEN_API_KEY", "Image generation API key"),
+    ("SN_API_KEY", "global SN API key for text, vision, and image generation"),
 ]
 
 

--- a/skills/sn-ppt-entry/SKILL.md
+++ b/skills/sn-ppt-entry/SKILL.md
@@ -22,7 +22,7 @@ triggers:
 
 ## Hard preconditions
 
-Run `sn-ppt-doctor` hard checks (SN_CHAT_API_KEY or SN_TEXT/SN_VISION API keys / SN_IMAGE_GEN_API_KEY / node / sn-image-base) at the start of this skill. If any fails, stop and tell the user to run `/skill sn-ppt-doctor`.
+Run `sn-ppt-doctor` hard checks (`SN_API_KEY` or capability-specific API keys / node / sn-image-base) at the start of this skill. If any fails, stop and tell the user to run `/skill sn-ppt-doctor`.
 
 ## Flow
 

--- a/skills/sn-ppt-entry/references/conventions.md
+++ b/skills/sn-ppt-entry/references/conventions.md
@@ -37,8 +37,8 @@ sn-ppt-standard 的 `scripts/run_stage.py` 对每个阶段都封装成 `python r
 用户把 `.env` 放哪都行（建议仓库根）。
 
 必填变量：
-- `SN_CHAT_API_KEY`（LLM/VLM 默认共享 key；可用 `SN_TEXT_API_KEY` / `SN_VISION_API_KEY` 分别覆盖）
-- `SN_IMAGE_GEN_API_KEY` + `SN_IMAGE_GEN_BASE_URL` + `SN_IMAGE_GEN_MODEL`
+- `SN_API_KEY`（LLM/VLM/图像生成默认共享 key；可用 `SN_CHAT_API_KEY`、`SN_TEXT_API_KEY`、`SN_VISION_API_KEY` 或 `SN_IMAGE_GEN_API_KEY` 分别覆盖）
+- `SN_BASE_URL` + `SN_IMAGE_GEN_MODEL`
 
 可选覆盖：`SN_CHAT_BASE_URL` / `SN_CHAT_TYPE` / `SN_CHAT_MODEL`、`SN_TEXT_*`、`SN_VISION_*`、`SN_CHAT_TIMEOUT` 等。
 

--- a/skills/sn-ppt-standard/SKILL.md
+++ b/skills/sn-ppt-standard/SKILL.md
@@ -111,8 +111,8 @@ The script is stateless — re-run a subcommand and it'll overwrite its output a
 
 Configured via `.env` at the repo root (or `<repo>/skills/.env`). `model_client.py` auto-loads both. Required:
 
-- `SN_CHAT_API_KEY` for shared text/vision chat auth, or per-kind overrides `SN_TEXT_API_KEY` / `SN_VISION_API_KEY`
-- `SN_IMAGE_GEN_API_KEY`, `SN_IMAGE_GEN_BASE_URL`, `SN_IMAGE_GEN_MODEL`
+- `SN_API_KEY` for shared text/vision/image-generation auth, or per-kind overrides `SN_CHAT_API_KEY` / `SN_TEXT_API_KEY` / `SN_VISION_API_KEY` / `SN_IMAGE_GEN_API_KEY`
+- `SN_BASE_URL`, `SN_IMAGE_GEN_MODEL`
 
 Optional `SN_CHAT_BASE_URL` / `SN_TEXT_BASE_URL` / `SN_VISION_BASE_URL`, `SN_CHAT_MODEL` / `SN_TEXT_MODEL` / `SN_VISION_MODEL`, and `SN_CHAT_TIMEOUT` / `SN_TEXT_TIMEOUT` / `SN_VISION_TIMEOUT` override defaults.
 


### PR DESCRIPTION
## Summary

- Add `SN_API_KEY` and `SN_BASE_URL` as global fallback values for SN capabilities.
- Preserve capability-specific priority: text and vision use dedicated vars, then `SN_CHAT_*`, then global `SN_*`; image generation uses `SN_IMAGE_GEN_*`, then global `SN_*`.
- Update `sn-image-doctor`, `sn-image-base`, `sn-image-resume`, and `sn-image-imitate` docs to describe the minimum shared-gateway configuration.

## Validation

- `SN_API_KEY` + `SN_BASE_URL` only: config resolution succeeds for text, vision, and image generation.
- Capability-specific values correctly override global values.
- `python skills/sn-image-doctor/scripts/check_environment.py` passes with only global SN vars set.
- `python -m py_compile` passes for the modified Python files.

## Notes

- No `SN_IMAGE_BASE_API_KEY` or `SN_IMAGE_BASE_BASE_URL` configuration variables are introduced.