### PR TITLE
docs: drop "Pro" from Raccoon plan and mention free trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The skills cover **image generation & visualization**, **slide-deck (PPT) genera
 
 ## 🦝 Available out-of-the-box in Raccoon
 
-The latest SenseNova models and the full Cowork-Skill suite in this repo are bundled into the [**Raccoon (小浣熊) Pro**](https://xiaohuanxiong.com/) plan, with enterprise-grade security and a zero-setup experience — if you'd rather not provision env, API keys, and runtimes yourself, you can use these capabilities directly through Raccoon.
+The latest SenseNova models and the full Cowork-Skill suite in this repo are bundled into [**Raccoon**](https://xiaohuanxiong.com/), with enterprise-grade security and a zero-setup experience — if you'd rather not provision env, API keys, and runtimes yourself, you can use these capabilities directly through Raccoon. Free trial available — no payment required to get started.
 
 Raccoon now ships a full upgrade across product capability and client experience:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -19,7 +19,7 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 
 ## 🦝 在小浣熊中开箱即用
 
-本仓库的最新模型与全系 Cowork-Skill，已整体集成进 [**小浣熊 Pro**](https://xiaohuanxiong.com/) 套餐，提供企业级安全防护与开箱即用的丝滑体验——如果你不想自己搭环境、配 API key，可以直接通过小浣熊使用这些能力。
+本仓库的最新模型与全系 Cowork-Skill，已整体集成进 [**小浣熊**](https://xiaohuanxiong.com/)，提供企业级安全防护与开箱即用的丝滑体验——如果你不想自己搭环境、配 API key，可以直接通过小浣熊使用这些能力。支持免费试用，无需付费即可上手体验。
 
 小浣熊本次迎来产品能力与客户端体验的全面升级：
 


### PR DESCRIPTION
## Summary
- Remove "Pro" from the Raccoon / 小浣熊 callout in both READMEs — there is no Pro tier
- Note that a free trial is available, no payment required

## Test plan
- [x] Render `README.md` and `README_CN.md` and verify the Raccoon section reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)