### PR TITLE
fix: align env vars with SN_* naming convention

### DIFF
--- a/skills/sn-da-image-caption/SKILL.md
+++ b/skills/sn-da-image-caption/SKILL.md
@@ -15,7 +15,7 @@ Analyze, extract data from, or understand image files (.png, .jpg, .jpeg, .gif, 
 
 ## scripts/caption.py — Image Caption
 
-The script converts images to text descriptions via a vision model. Set `VISION_API_KEY` and `VISION_API_BASE` environment variables before running.
+The script converts images to text descriptions via a vision model. Configure via `SN_API_KEY` (minimum required), or use `SN_VISION_API_KEY` / `SN_VISION_BASE_URL` / `SN_VISION_MODEL` for fine-grained control. See the project environment variable spec for the full fallback chain.
 
 ### Usage
 
@@ -41,7 +41,7 @@ python3 scripts/caption.py /mnt/data/image.png --model gemini-3.1-flash-lite-pre
 | Option | Description |
 |--------|------------|
 | `--prompt, -p` | Custom prompt (overrides auto-detection) |
-| `--model, -m` | Vision model (default: gpt-4o) |
+| `--model, -m` | Vision model (default: sensenova-6.7-flash-lite) |
 | `--json` | Output structured JSON instead of plain text |
 | `--batch` | Process all images in a directory |
 | `--output, -o` | Output file for batch results |

--- a/skills/sn-da-image-caption/scripts/caption.py
+++ b/skills/sn-da-image-caption/scripts/caption.py
@@ -42,12 +42,29 @@ JPEG_QUALITY = 75
 CACHE_DIR = os.path.join(os.path.dirname(__file__), ".caption_cache")
 
 # ─── API settings (configure via environment variables) ─────────────
-# Set VISION_API_KEY and VISION_API_BASE before use.
-# VISION_API_BASE should point to an OpenAI-compatible endpoint.
+# Fallback chain: SN_VISION_* → SN_CHAT_* → SN_* → built-in default
+# Minimum setup: set SN_API_KEY
 
-DEFAULT_API_KEY = os.environ.get("VISION_API_KEY", "")
-DEFAULT_API_BASE = os.environ.get("VISION_API_BASE", "https://api.openai.com/v1")
-DEFAULT_MODEL = os.environ.get("VISION_MODEL", "gpt-4o")
+_BUILTIN_BASE_URL = "https://token.sensenova.cn/v1"
+_BUILTIN_MODEL = "sensenova-6.7-flash-lite"
+
+DEFAULT_API_KEY = (
+    os.environ.get("SN_VISION_API_KEY")
+    or os.environ.get("SN_CHAT_API_KEY")
+    or os.environ.get("SN_API_KEY")
+    or ""
+)
+DEFAULT_API_BASE = (
+    os.environ.get("SN_VISION_BASE_URL")
+    or os.environ.get("SN_CHAT_BASE_URL")
+    or os.environ.get("SN_BASE_URL")
+    or _BUILTIN_BASE_URL
+)
+DEFAULT_MODEL = (
+    os.environ.get("SN_VISION_MODEL")
+    or os.environ.get("SN_CHAT_MODEL")
+    or _BUILTIN_MODEL
+)
 
 # ─── Prompt templates ───────────────────────────────────────────────
 
@@ -269,9 +286,9 @@ def caption_image(
         return {"file": image_path, "error": f"Unsupported format: {ext}"}
 
     # Resolve config (pre-configured defaults, no setup needed)
-    model = model or os.environ.get("VISION_MODEL", DEFAULT_MODEL)
-    api_key = api_key or os.environ.get("VISION_API_KEY", DEFAULT_API_KEY)
-    api_base = api_base or os.environ.get("VISION_API_BASE", DEFAULT_API_BASE)
+    model = model or DEFAULT_MODEL
+    api_key = api_key or DEFAULT_API_KEY
+    api_base = api_base or DEFAULT_API_BASE
 
     # Detect type & prompt
     img_type = detect_image_type(os.path.basename(image_path), context)
@@ -353,7 +370,7 @@ def main():
     parser.add_argument("path", help="Image file path or directory (with --batch)")
     parser.add_argument("--prompt", "-p", default=None, help="Custom prompt")
     parser.add_argument("--model", "-m", default=None, help="Vision model name")
-    parser.add_argument("--api-key", default=None, help="API key (or set VISION_API_KEY)")
+    parser.add_argument("--api-key", default=None, help="API key (or set SN_API_KEY / SN_VISION_API_KEY)")
     parser.add_argument("--api-base", default=None, help="API base URL")
     parser.add_argument("--batch", action="store_true", help="Process all images in directory")
     parser.add_argument("--output", "-o", default=None, help="Output file for batch results (JSON)")


### PR DESCRIPTION
Replace legacy VISION_API_KEY/VISION_API_BASE/VISION_MODEL with the standard fallback chain (SN_VISION_* → SN_CHAT_* → SN_*) and update default values per the project env var spec.