### PR TITLE
docs: update Agent Pack repo URL to OpenSenseNova org

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ Both agents below will use the same three values:
 
 ## 0.5. Quick install via Agent Pack (optional)
 
-If you'd rather skip the manual steps below, [Agent Pack](https://github.com/SenseTime-FVG/agent_pack) is a one-click installer that handles everything in this guide for you:
+If you'd rather skip the manual steps below, [Agent Pack](https://github.com/OpenSenseNova/agent_pack) is a one-click installer that handles everything in this guide for you:
 
 - Installs OpenClaw and/or hermes-agent via each project's official installer
 - Configures the LLM provider (pick **Custom** and paste the values from §0)
@@ -33,13 +33,13 @@ If you'd rather skip the manual steps below, [Agent Pack](https://github.com/Sen
 
 > Platform-level prerequisites (WSL2 on Windows, Xcode CLT + Homebrew on macOS) are **not** auto-installed — finish §1.1 / §1.2 below for your platform first, then come back here. Linux has no manual prerequisites.
 
-Pre-built installers live on the [GitHub Releases page](https://github.com/SenseTime-FVG/agent_pack/releases/latest):
+Pre-built installers live on the [GitHub Releases page](https://github.com/OpenSenseNova/agent_pack/releases/latest):
 
 | Platform | Download | How to use |
 |----------|----------|------------|
-| Windows | [`-windows-x64.exe` from the latest release](https://github.com/SenseTime-FVG/agent_pack/releases/latest) | Double-click and follow the wizard; installation runs inside WSL2, and the PowerShell window is taken over by the installed agent when setup finishes. |
-| macOS | [`-macos-universal.pkg` from the latest release](https://github.com/SenseTime-FVG/agent_pack/releases/latest) | Double-click, then complete the macOS wizard for product selection and LLM configuration; on finish it opens the OpenClaw Gateway Terminal + dashboard, and/or the Hermes Terminal as selected. |
-| Linux | [`-linux.sh` from the latest release](https://github.com/SenseTime-FVG/agent_pack/releases/latest), or the one-liner on the right | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`, or paste `bash <(curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/agent_pack/main/linux/install.sh)` — either way the shell that ran the installer is handed over to the agent via `exec`. |
+| Windows | [`-windows-x64.exe` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest) | Double-click and follow the wizard; installation runs inside WSL2, and the PowerShell window is taken over by the installed agent when setup finishes. |
+| macOS | [`-macos-universal.pkg` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest) | Double-click, then complete the macOS wizard for product selection and LLM configuration; on finish it opens the OpenClaw Gateway Terminal + dashboard, and/or the Hermes Terminal as selected. |
+| Linux | [`-linux.sh` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest), or the one-liner on the right | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`, or paste `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` — either way the shell that ran the installer is handed over to the agent via `exec`. |
 
 When the installer asks for the LLM provider, choose **Custom (OpenAI-compatible)** and feed in the three values from §0 (Base URL, API key, model name). If you're in a China-region network, set `AGENTPACK_CN=1` to enable the GitHub mirror fallbacks.
 

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -24,7 +24,7 @@
 
 ## 0.5. 一键安装：Agent Pack（可选）
 
-如果不想手动跟着下面的步骤一路装下来，可以直接用 [Agent Pack](https://github.com/SenseTime-FVG/agent_pack) —— 一个跨平台一键安装器，把本文档里的所有步骤都帮你处理好：
+如果不想手动跟着下面的步骤一路装下来，可以直接用 [Agent Pack](https://github.com/OpenSenseNova/agent_pack) —— 一个跨平台一键安装器，把本文档里的所有步骤都帮你处理好：
 
 - 调用 OpenClaw 和/或 hermes-agent 的官方安装脚本完成安装
 - 配置 LLM 供应商（选 **Custom**，把 §0 里的三个值填进去即可）
@@ -33,13 +33,13 @@
 
 > 平台级前提（Windows 上的 WSL2、macOS 上的 Xcode CLT + Homebrew）**不会**被自动安装 —— 请先按照下面 §1.1 / §1.2 完成你所在平台的前置准备，然后回到这一节继续。Linux 无需手动准备。
 
-预编译的安装器发布在 [GitHub Releases 页面](https://github.com/SenseTime-FVG/agent_pack/releases/latest)：
+预编译的安装器发布在 [GitHub Releases 页面](https://github.com/OpenSenseNova/agent_pack/releases/latest)：
 
 | 平台 | 下载 | 使用方式 |
 |------|------|---------|
-| Windows | [去最新 release 下载 `-windows-x64.exe`](https://github.com/SenseTime-FVG/agent_pack/releases/latest) | 双击运行向导；安装过程在 WSL2 中执行，安装完成后当前 PowerShell 窗口会被接管，直接拉起 agent。 |
-| macOS | [去最新 release 下载 `-macos-universal.pkg`](https://github.com/SenseTime-FVG/agent_pack/releases/latest) | 双击后按图形向导完成产品选择和 LLM 配置；安装完成后会按所选产品自动打开 OpenClaw Gateway Terminal 与 dashboard，并打开 Hermes Terminal。 |
-| Linux | [去最新 release 下载 `-linux.sh`](https://github.com/SenseTime-FVG/agent_pack/releases/latest)，或使用右侧一行命令 | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`，或直接粘贴 `bash <(curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/agent_pack/main/linux/install.sh)` —— 两种方式都会在安装结束后用 `exec` 在当前 shell 里拉起 agent。 |
+| Windows | [去最新 release 下载 `-windows-x64.exe`](https://github.com/OpenSenseNova/agent_pack/releases/latest) | 双击运行向导；安装过程在 WSL2 中执行，安装完成后当前 PowerShell 窗口会被接管，直接拉起 agent。 |
+| macOS | [去最新 release 下载 `-macos-universal.pkg`](https://github.com/OpenSenseNova/agent_pack/releases/latest) | 双击后按图形向导完成产品选择和 LLM 配置；安装完成后会按所选产品自动打开 OpenClaw Gateway Terminal 与 dashboard，并打开 Hermes Terminal。 |
+| Linux | [去最新 release 下载 `-linux.sh`](https://github.com/OpenSenseNova/agent_pack/releases/latest)，或使用右侧一行命令 | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`，或直接粘贴 `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` —— 两种方式都会在安装结束后用 `exec` 在当前 shell 里拉起 agent。 |
 
 安装器询问 LLM 供应商时，选 **Custom (OpenAI-compatible)**，把 §0 里的三个值填进去（Base URL、API Key、模型名）。如果你处在国内网络，可以设置环境变量 `AGENTPACK_CN=1` 启用 GitHub 镜像回退。
 


### PR DESCRIPTION
## Summary
- Replace `SenseTime-FVG/agent_pack` with `OpenSenseNova/agent_pack` in INSTALL.md and INSTALL_CN.md
- Updates the main repo link, GitHub Releases links (Windows/macOS/Linux downloads), and the `raw.githubusercontent.com` one-liner

## Test plan
- [ ] Verify all links in INSTALL.md and INSTALL_CN.md point to the OpenSenseNova org
- [ ] Confirm no remaining references to `SenseTime-FVG/agent_pack` in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)