### PR TITLE
refactor(sn-image-base, sn-infographic): unify error schema, add 4k image-size, tighten Worker pipeline

### DIFF
--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -48,7 +48,7 @@ Image generation tool that calls the text-to-image-no-enhance API.
 |------|------|--------|------|
 | `--prompt` | string | **Required** | Prompt text for image generation |
 | `--negative-prompt` | string | `""` | Negative prompt |
-| `--image-size` | string | `2k` | Image size preset, supports `2k` only |
+| `--image-size` | string | `2k` | Image size preset, `2k` only (case-insensitive); invalid value → `status=failed` JSON |
 | `--aspect-ratio` | string | `16:9` | Aspect ratio, e.g. `1:1`, `16:9`, `9:16` |
 | `--seed` | int | `None` | Random seed for reproducible generation |
 | `--unet-name` | string | `None` | Specify a UNet model name |

--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -48,7 +48,7 @@ Image generation tool that calls the text-to-image-no-enhance API.
 |------|------|--------|------|
 | `--prompt` | string | **Required** | Prompt text for image generation |
 | `--negative-prompt` | string | `""` | Negative prompt |
-| `--image-size` | string | `2k` | Image size preset, `2k` only (case-insensitive); invalid value → `status=failed` JSON |
+| `--image-size` | string | `2k` | Image size preset (case-insensitive). Recommended: `2k`. `4k` optional, needs model support (sensenova rejects it → `status=failed`). Other values → `status=failed`. |
 | `--aspect-ratio` | string | `16:9` | Aspect ratio, e.g. `1:1`, `16:9`, `9:16` |
 | `--seed` | int | `None` | Random seed for reproducible generation |
 | `--unet-name` | string | `None` | Specify a UNet model name |

--- a/skills/sn-image-base/references/api_spec.md
+++ b/skills/sn-image-base/references/api_spec.md
@@ -92,7 +92,7 @@ Error: API key is required but was not provided. Set SN_API_KEY, or set SN_IMAGE
 **json format**:
 
 ```json
-{"status": "failed", "error": "API key is required but was not provided. Set SN_API_KEY, or set SN_IMAGE_GEN_API_KEY only for an image-generation-specific override, or pass --api-key explicitly.", "elapsed_seconds": 0.05}
+{"status": "failed", "error_type": "MissingApiKeyError", "error": "API key is required but was not provided. Set SN_API_KEY, or set SN_IMAGE_GEN_API_KEY only for an image-generation-specific override, or pass --api-key explicitly.", "elapsed_seconds": 0.05}
 ```
 
 ---
@@ -253,30 +253,33 @@ appends only the interface endpoint path.
 
 ## Error Handling
 
-### Error Types
-
-| Type | Source | Trigger | Output Format |
-|------|--------|---------|---------------|
-| `MissingApiKeyError` | Custom business exception | API Key not provided for `sn-image-generate` | text: `Error: ...` / json: `{"status": "failed", "error": "..."}` |
-| `ValueError` | `_resolve_prompt`, `run_image_generate` | prompt mutual-exclusion / neither provided / file-read failure; `--image-size` not in the allowed set | text: `Error: ...` / json: `{"status": "failed", "error": "..."}` |
-| argparse missing param | argparse standard error | Missing required parameters for `sn-image-recognize`/`sn-text-optimize` | `usage: ...` + exit 2 |
-| HTTP error | httpx request layer | API returns non-2xx status code | `{"status": "failed", "error": "HTTP NNN", "message": "..."}` |
-| Request exception | httpx request layer | Network error, timeout, etc. | `{"status": "failed", "error": "<ExceptionType>", "message": "..."}` |
-
-### text format
-
-Error messages are written to stderr and do not affect stdout content.
-
-### json format
+All failure responses share the same JSON schema:
 
 ```json
 {
   "status": "failed",
-  "error": "error type",
-  "message": "detailed error message",
+  "error_type": "<exception class name or synthetic tag>",
+  "error": "<human-readable details>",
   "elapsed_seconds": 0.05
 }
 ```
+
+- `error_type`: the Python exception class name (e.g. `ValueError`, `MissingApiKeyError`, `HTTPStatusError`) for caught exceptions, or a synthetic tag (e.g. `EmptyResponse`) when the failure is not an exception. Agents can branch on this field to decide retry vs surface-to-user.
+- `error`: the human-readable detail string. For HTTP errors this includes the status code and response body; for ValueError / config errors this is the message thrown by the call site.
+- `elapsed_seconds`: wall-time the runner spent before returning the failure.
+
+In text mode, `error` is written to stderr (no `error_type` prefix). `stdout` is unaffected on failure.
+
+### Error sources
+
+| `error_type` | Source | Trigger |
+|--------------|--------|---------|
+| `MissingApiKeyError` | Custom business exception | API key not provided for `sn-image-generate` |
+| `ValueError` | `_resolve_prompt`, `run_image_generate`, backend `_resolve_size` | prompt mutual-exclusion / file-read failure; `--image-size` not in the allowed set; unsupported resolution / aspect ratio inside backend |
+| argparse missing param | argparse standard error | Missing required parameters for `sn-image-recognize` / `sn-text-optimize` (still exits via argparse's stderr + exit 2; **not** unified) |
+| `HTTPStatusError` (or backend's `U1HttpError` subclass) | httpx request layer | API returns non-2xx status code |
+| `httpx.HTTPError` / `OSError` | httpx request layer | Network error, timeout, etc. |
+| `EmptyResponse` | Backend post-processing | API returned 2xx but no image in the response |
 
 ---
 

--- a/skills/sn-image-base/references/api_spec.md
+++ b/skills/sn-image-base/references/api_spec.md
@@ -40,7 +40,7 @@ python sn_agent_runner.py sn-image-generate \
 | `--api-key` | string | No | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | API Key (CLI takes precedence; raises `MissingApiKeyError` if all are empty) |
 | `--base-url` | string | No | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` | API base URL (CLI takes precedence) |
 | `--negative-prompt` | string | No | `""` | Negative prompt |
-| `--image-size` | string | No | `"2k"` | Image size: `2k` only (case-insensitive); invalid value raises `ValueError` (see Error Handling) |
+| `--image-size` | string | No | `"2k"` | Image size (case-insensitive). Recommended: `2k`. `4k` optional, needs model support (sensenova rejects it → `ValueError`). Other values → `ValueError` (see Error Handling). |
 | `--aspect-ratio` | string | No | `"16:9"` | Aspect ratio |
 | `--seed` | int | No | `None` | Random seed (for reproducibility) |
 | `--unet-name` | string | No | `None` | UNet model name |
@@ -275,7 +275,7 @@ In text mode, `error` is written to stderr (no `error_type` prefix). `stdout` is
 | `error_type` | Source | Trigger |
 |--------------|--------|---------|
 | `MissingApiKeyError` | Custom business exception | API key not provided for `sn-image-generate` |
-| `ValueError` | `_resolve_prompt`, `run_image_generate`, backend `_resolve_size` | prompt mutual-exclusion / file-read failure; `--image-size` not in the allowed set; unsupported resolution / aspect ratio inside backend |
+| `ValueError` | `_resolve_prompt`, `run_image_generate`, backend `_resolve_size` | prompt mutual-exclusion / file-read failure; `--image-size` not in the allowed input set; `4k` on unsupported models (1K/2K only); unsupported aspect ratio inside backend |
 | argparse missing param | argparse standard error | Missing required parameters for `sn-image-recognize` / `sn-text-optimize` (still exits via argparse's stderr + exit 2; **not** unified) |
 | `HTTPStatusError` (or backend's `U1HttpError` subclass) | httpx request layer | API returns non-2xx status code |
 | `httpx.HTTPError` / `OSError` | httpx request layer | Network error, timeout, etc. |

--- a/skills/sn-image-base/references/api_spec.md
+++ b/skills/sn-image-base/references/api_spec.md
@@ -40,7 +40,7 @@ python sn_agent_runner.py sn-image-generate \
 | `--api-key` | string | No | `SN_IMAGE_GEN_API_KEY` -> `SN_API_KEY` | API Key (CLI takes precedence; raises `MissingApiKeyError` if all are empty) |
 | `--base-url` | string | No | `SN_IMAGE_GEN_BASE_URL` -> `SN_BASE_URL` | API base URL (CLI takes precedence) |
 | `--negative-prompt` | string | No | `""` | Negative prompt |
-| `--image-size` | string | No | `"2k"` | Image size: `2k` only |
+| `--image-size` | string | No | `"2k"` | Image size: `2k` only (case-insensitive); invalid value raises `ValueError` (see Error Handling) |
 | `--aspect-ratio` | string | No | `"16:9"` | Aspect ratio |
 | `--seed` | int | No | `None` | Random seed (for reproducibility) |
 | `--unet-name` | string | No | `None` | UNet model name |
@@ -258,7 +258,7 @@ appends only the interface endpoint path.
 | Type | Source | Trigger | Output Format |
 |------|--------|---------|---------------|
 | `MissingApiKeyError` | Custom business exception | API Key not provided for `sn-image-generate` | text: `Error: ...` / json: `{"status": "failed", "error": "..."}` |
-| `ValueError` (prompt) | `_resolve_prompt` | `--user-prompt` and `--user-prompt-path` both provided, neither provided, or file read failure | text: `Error: ...` / json: `{"status": "failed", "error": "..."}` |
+| `ValueError` | `_resolve_prompt`, `run_image_generate` | prompt mutual-exclusion / neither provided / file-read failure; `--image-size` not in the allowed set | text: `Error: ...` / json: `{"status": "failed", "error": "..."}` |
 | argparse missing param | argparse standard error | Missing required parameters for `sn-image-recognize`/`sn-text-optimize` | `usage: ...` + exit 2 |
 | HTTP error | httpx request layer | API returns non-2xx status code | `{"status": "failed", "error": "HTTP NNN", "message": "..."}` |
 | Request exception | httpx request layer | Network error, timeout, etc. | `{"status": "failed", "error": "<ExceptionType>", "message": "..."}` |

--- a/skills/sn-image-base/scripts/extract_json.py
+++ b/skills/sn-image-base/scripts/extract_json.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Recover a single JSON value from noisy stdin and print it canonically.
+
+LLM and CLI output sometimes wraps JSON in prose ("Here is the result:"),
+markdown code fences (```json ... ```), or trailing commentary. This helper
+reads stdin, recovers the JSON value, and writes it (compact, UTF-8) to stdout.
+
+Recovery order:
+    1. Parse the whole input as-is.
+    2. Strip a surrounding markdown code fence, then parse.
+    3. Slice from the first opening bracket to its balanced close (string- and
+       escape-aware), then parse.
+
+Exit code 0 on success; 1 (with a message on stderr) when no JSON is found.
+Usage: some_command | python extract_json.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _strip_fence(text: str) -> str:
+    """Remove a single surrounding ``` / ```json markdown fence, if present."""
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    lines = stripped.splitlines()
+    # Drop the opening fence line (``` or ```json) and a trailing fence line.
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines)
+
+
+def _balanced_span(text: str) -> str | None:
+    """Return the substring from the first { or [ to its matching close.
+
+    Tracks string literals and escapes so braces inside strings don't count.
+    Returns None when no balanced span is found.
+    """
+    starts = [(text.find(o), o, c) for o, c in (("{", "}"), ("[", "]"))]
+    starts = [s for s in starts if s[0] != -1]
+    if not starts:
+        return None
+    start, open_ch, close_ch = min(starts, key=lambda t: t[0])
+
+    depth = 0
+    in_str = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == open_ch:
+            depth += 1
+        elif ch == close_ch:
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+def extract_json(raw: str):
+    """Recover a JSON value from raw text, or raise ValueError if none found."""
+    candidates = [raw, _strip_fence(raw)]
+    span = _balanced_span(raw)
+    if span is not None:
+        candidates.append(span)
+    for candidate in candidates:
+        candidate = candidate.strip()
+        if not candidate:
+            continue
+        try:
+            return json.loads(candidate)
+        except ValueError:
+            continue
+    raise ValueError("no valid JSON value found in input")
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        value = extract_json(raw)
+    except ValueError as exc:
+        sys.stderr.write(f"extract_json: {exc}\n")
+        return 1
+    sys.stdout.write(json.dumps(value, ensure_ascii=False))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/sn-image-base/scripts/extract_json.py
+++ b/skills/sn-image-base/scripts/extract_json.py
@@ -8,8 +8,9 @@ reads stdin, recovers the JSON value, and writes it (compact, UTF-8) to stdout.
 Recovery order:
     1. Parse the whole input as-is.
     2. Strip a surrounding markdown code fence, then parse.
-    3. Slice from the first opening bracket to its balanced close (string- and
-       escape-aware), then parse.
+    3. Scan each opening bracket to its balanced close (string- and
+       escape-aware), trying successive openers until one parses — so a valid
+       object/array after some junk is still recovered.
 
 Exit code 0 on success; 1 (with a message on stderr) when no JSON is found.
 Usage: some_command | python extract_json.py
@@ -17,8 +18,13 @@ Usage: some_command | python extract_json.py
 
 from __future__ import annotations
 
+import itertools
 import json
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _strip_fence(text: str) -> str:
@@ -35,18 +41,12 @@ def _strip_fence(text: str) -> str:
     return "\n".join(lines)
 
 
-def _balanced_span(text: str) -> str | None:
-    """Return the substring from the first { or [ to its matching close.
+def _scan_balanced(text: str, start: int, open_ch: str, close_ch: str) -> int | None:
+    """Return the index of the close that balances the opener at ``start``.
 
-    Tracks string literals and escapes so braces inside strings don't count.
-    Returns None when no balanced span is found.
+    Tracks string literals and escapes so brackets inside strings don't count.
+    Returns None when the opener is never balanced.
     """
-    starts = [(text.find(o), o, c) for o, c in (("{", "}"), ("[", "]"))]
-    starts = [s for s in starts if s[0] != -1]
-    if not starts:
-        return None
-    start, open_ch, close_ch = min(starts, key=lambda t: t[0])
-
     depth = 0
     in_str = False
     escape = False
@@ -67,16 +67,31 @@ def _balanced_span(text: str) -> str | None:
         elif ch == close_ch:
             depth -= 1
             if depth == 0:
-                return text[start : i + 1]
+                return i
     return None
+
+
+def _balanced_spans(text: str) -> Iterator[str]:
+    """Yield balanced {...} / [...] substrings in opening-bracket order.
+
+    Scans successive openers so a later valid object/array is still found when
+    an earlier bracket region is not valid JSON. Nested openers are included;
+    the caller stops at the first span that parses.
+    """
+    for i, ch in enumerate(text):
+        if ch == "{":
+            end = _scan_balanced(text, i, "{", "}")
+        elif ch == "[":
+            end = _scan_balanced(text, i, "[", "]")
+        else:
+            continue
+        if end is not None:
+            yield text[i : end + 1]
 
 
 def extract_json(raw: str):
     """Recover a JSON value from raw text, or raise ValueError if none found."""
-    candidates = [raw, _strip_fence(raw)]
-    span = _balanced_span(raw)
-    if span is not None:
-        candidates.append(span)
+    candidates = itertools.chain((raw, _strip_fence(raw)), _balanced_spans(raw))
     for candidate in candidates:
         candidate = candidate.strip()
         if not candidate:

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -214,9 +214,10 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
 
     Returns:
         tuple[dict, int]:
-            A (result_dict, exit_code) pair. result_dict contains status,
-            output (image path), task_id, and message. exit_code is 0 on
-            success and 1 on failure.
+            A (result_dict, exit_code) pair. On success result_dict contains
+            status, output (image path), and message. On failure it contains
+            status, error_type, and error. exit_code is 0 on success and 1 on
+            failure.
     """
     normalized_size = args.image_size.strip().lower()
     if normalized_size not in ALLOWED_IMAGE_SIZES:

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -251,7 +251,10 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
             timeout=args.timeout,
             ssl_verify=not args.insecure,
         )
-        print(f"Using SenseNova model {global_configs.SN_IMAGE_GEN_MODEL!r} for image generation")
+        print(
+            f"Using SenseNova model {global_configs.SN_IMAGE_GEN_MODEL!r} for image generation",
+            file=sys.stderr,
+        )
     elif global_configs.SN_IMAGE_GEN_MODEL_TYPE == "nano-banana":
         if not global_configs.SN_IMAGE_GEN_MODEL:
             env_var_help = global_configs.get_env_var_help("SN_IMAGE_GEN_MODEL")
@@ -263,7 +266,10 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
             timeout=args.timeout,
             ssl_verify=not args.insecure,
         )
-        print(f"Using Nano Banana model {global_configs.SN_IMAGE_GEN_MODEL!r} for image generation")
+        print(
+            f"Using Nano Banana model {global_configs.SN_IMAGE_GEN_MODEL!r} for image generation",
+            file=sys.stderr,
+        )
     elif global_configs.SN_IMAGE_GEN_MODEL_TYPE == "openai-image":
         if not global_configs.SN_IMAGE_GEN_MODEL:
             env_var_help = global_configs.get_env_var_help("SN_IMAGE_GEN_MODEL")
@@ -274,7 +280,8 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
             model=global_configs.SN_IMAGE_GEN_MODEL,
         )
         print(
-            f"Using OpenAI-compatible model {global_configs.SN_IMAGE_GEN_MODEL!r} for image generation"
+            f"Using OpenAI-compatible model {global_configs.SN_IMAGE_GEN_MODEL!r} for image generation",
+            file=sys.stderr,
         )
     else:
         supported_types = "sensenova, nano-banana, openai-image"
@@ -488,7 +495,10 @@ def _build_endpoint_and_adapter(
             api_key=api_key,
             model=model,
         )
-        print(f"Using Anthropic Messages adapter for {kind.upper()} {model!r} on {endpoint_url!r}")
+        print(
+            f"Using Anthropic Messages adapter for {kind.upper()} {model!r} on {endpoint_url!r}",
+            file=sys.stderr,
+        )
     else:
         endpoint = "/v1/chat/completions" if not base_url_obj.path else "/chat/completions"
         endpoint_url = f"{base_url_obj.geturl()}{endpoint}"
@@ -499,7 +509,10 @@ def _build_endpoint_and_adapter(
             api_key=api_key,
             model=model,
         )
-        print(f"Using OpenAI Chat adapter for {kind.upper()} {model!r} on {endpoint_url!r}")
+        print(
+            f"Using OpenAI Chat adapter for {kind.upper()} {model!r} on {endpoint_url!r}",
+            file=sys.stderr,
+        )
 
     return adapter
 

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -338,7 +338,7 @@ async def run_image_recognize(args: argparse.Namespace) -> tuple[dict, int]:
             "interface_type": vlm_type,
         }, 0
     except Exception as exc:
-        return {"status": "failed", "error": str(exc)}, 1
+        return {"status": "failed", "error_type": type(exc).__name__, "error": str(exc)}, 1
     finally:
         await adapter.aclose()
 
@@ -384,7 +384,7 @@ async def run_text_optimize(args: argparse.Namespace) -> tuple[dict, int]:
             "interface_type": llm_type,
         }, 0
     except Exception as exc:
-        return {"status": "failed", "error": str(exc)}, 1
+        return {"status": "failed", "error_type": type(exc).__name__, "error": str(exc)}, 1
     finally:
         await adapter.aclose()
 
@@ -526,7 +526,7 @@ def _output_result(output_format: str, result: dict, elapsed: float | None = Non
             # text-optimize/image-recognize use "result", image-generate uses "output"
             print(result.get("result") or result.get("output") or "")
         else:
-            print(result.get("message") or result["error"], file=sys.stderr)
+            print(result["error"], file=sys.stderr)
     return 0 if result["status"] == "ok" else 1
 
 
@@ -559,7 +559,7 @@ async def main_async(args: argparse.Namespace) -> int:
         if args.output_format == "json":
             print(
                 json.dumps(
-                    {"status": "failed", "error": str(exc), "elapsed_seconds": elapsed},
+                    {"status": "failed", "error_type": type(exc).__name__, "error": str(exc), "elapsed_seconds": elapsed},
                     ensure_ascii=False,
                 )
             )
@@ -572,7 +572,7 @@ async def main_async(args: argparse.Namespace) -> int:
         if args.output_format == "json":
             print(
                 json.dumps(
-                    {"status": "failed", "error": str(exc), "elapsed_seconds": elapsed},
+                    {"status": "failed", "error_type": type(exc).__name__, "error": str(exc), "elapsed_seconds": elapsed},
                     ensure_ascii=False,
                 )
             )

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -37,10 +37,12 @@ from sn_image_base.generation import (
 from sn_image_base.llm import AnthropicMessagesAdapter, OpenAIChatAdapter
 
 # Allowed --image-size values, canonical lowercase form. Comparison is
-# case-insensitive (see run_image_generate). Pipeline currently locked to 2k
-# (PR #80); 1k / 4k remain available in the backend if a future caller adds
-# them here.
-ALLOWED_IMAGE_SIZES = frozenset({"2k"})
+# case-insensitive (see run_image_generate). The runner forwards both 2k and 4k
+# to the configured backend; each backend then either renders the size, forwards
+# it upstream, or rejects it (e.g. the sensenova backend rejects 4k since it only
+# has 1K / 2K buckets). Any rejection surfaces as a status=failed JSON. 1k remains
+# backend-only until a caller adds it here.
+ALLOWED_IMAGE_SIZES = frozenset({"2k", "4k"})
 
 
 def _resolve_prompt(
@@ -88,7 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     gen_parser.add_argument(
         "--image-size",
         default="2k",
-        help="Image size preset (case-insensitive; only '2k' is currently supported)",
+        help="Image size preset (case-insensitive), e.g. '2k' or '4k'; forwarded to the upstream model, which may reject an unsupported size",
     )
     gen_parser.add_argument(
         "--aspect-ratio",
@@ -221,10 +223,10 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
     """
     normalized_size = args.image_size.strip().lower()
     if normalized_size not in ALLOWED_IMAGE_SIZES:
+        accepted = ", ".join(sorted(ALLOWED_IMAGE_SIZES))
         raise ValueError(
             f"image-size {args.image_size!r} is not supported. "
-            f"Accepted values (case-insensitive): {sorted(ALLOWED_IMAGE_SIZES)}. "
-            f"Retry with --image-size 2k."
+            f"Accepted values (case-insensitive): {accepted}."
         )
     args.image_size = normalized_size
 

--- a/skills/sn-image-base/scripts/sn_agent_runner.py
+++ b/skills/sn-image-base/scripts/sn_agent_runner.py
@@ -36,6 +36,12 @@ from sn_image_base.generation import (
 )
 from sn_image_base.llm import AnthropicMessagesAdapter, OpenAIChatAdapter
 
+# Allowed --image-size values, canonical lowercase form. Comparison is
+# case-insensitive (see run_image_generate). Pipeline currently locked to 2k
+# (PR #80); 1k / 4k remain available in the backend if a future caller adds
+# them here.
+ALLOWED_IMAGE_SIZES = frozenset({"2k"})
+
 
 def _resolve_prompt(
     direct: str | None,
@@ -80,7 +86,9 @@ def build_parser() -> argparse.ArgumentParser:
     gen_parser.add_argument("--prompt", required=True, help="Text prompt for image generation")
     gen_parser.add_argument("--negative-prompt", default="", help="Negative prompt")
     gen_parser.add_argument(
-        "--image-size", default="2k", choices=["2k"], help="Image size preset"
+        "--image-size",
+        default="2k",
+        help="Image size preset (case-insensitive; only '2k' is currently supported)",
     )
     gen_parser.add_argument(
         "--aspect-ratio",
@@ -210,6 +218,15 @@ async def run_image_generate(args: argparse.Namespace) -> tuple[dict, int]:
             output (image path), task_id, and message. exit_code is 0 on
             success and 1 on failure.
     """
+    normalized_size = args.image_size.strip().lower()
+    if normalized_size not in ALLOWED_IMAGE_SIZES:
+        raise ValueError(
+            f"image-size {args.image_size!r} is not supported. "
+            f"Accepted values (case-insensitive): {sorted(ALLOWED_IMAGE_SIZES)}. "
+            f"Retry with --image-size 2k."
+        )
+    args.image_size = normalized_size
+
     api_key = args.api_key or global_configs.SN_IMAGE_GEN_API_KEY
     if not api_key:
         raise MissingApiKeyError(global_configs.get_env_var_help("SN_IMAGE_GEN_API_KEY"))

--- a/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
@@ -100,7 +100,8 @@ class NanoBananaText2ImageClient(T2IBaseClient):
 
         Returns:
             dict:
-                Dictionary with keys: status, output (path), message.
+                On success, keys: status, output (path), message. On failure,
+                keys: status, error_type, error.
         """
         model = model or self.model
         # Normalize image_size to uppercase for NanoBanana API
@@ -278,9 +279,9 @@ class NanoBananaText2ImageClient(T2IBaseClient):
                 finish_reasons.append(f_reason)
             for p in parts:
                 inline_data: dict[str, Any] = p.get("inlineData", {})
-                if inline_data:
-                    mime_type: str = inline_data.get("mimeType")  # pyright: ignore[reportAssignmentType]
-                    data: str = inline_data.get("data")  # pyright: ignore[reportAssignmentType]
+                mime_type = inline_data.get("mimeType")
+                data = inline_data.get("data")
+                if isinstance(mime_type, str) and isinstance(data, str):
                     images.append((data, mime_type))
         return {
             "images": images,

--- a/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
@@ -150,14 +150,15 @@ class NanoBananaText2ImageClient(T2IBaseClient):
                             details += f"\nIs any of the following environment variable(s) set correctly: {env_names_str}?"
             return {
                 "status": "failed",
-                "error": f"HTTP {exc.code}: {exc.message}",
-                "message": details,
+                "error_type": type(exc).__name__,
+                "error": f"HTTP {exc.code}: {exc.message}" + (f"\n{details}" if details else ""),
             }
         try:
             images = data["images"]
             if not images:
                 return {
                     "status": "failed",
+                    "error_type": "EmptyResponse",
                     "error": "No image generated from the model",
                 }
             image, mime_type = images[-1]
@@ -173,14 +174,14 @@ class NanoBananaText2ImageClient(T2IBaseClient):
         except httpx.HTTPStatusError as exc:
             return {
                 "status": "failed",
-                "error": f"HTTP {exc.response.status_code}",
-                "message": f"http error: {exc.response.status_code} {exc.response.text}",
+                "error_type": type(exc).__name__,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text}",
             }
         except (httpx.HTTPError, OSError, ValueError) as exc:
             return {
                 "status": "failed",
-                "error": type(exc).__name__,
-                "message": f"request error: {exc}",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
             }
 
     @property

--- a/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
@@ -338,8 +338,10 @@ class OpenAIImageGenerationClient(T2IBaseClient):
             max_pixel = 1024**2
         elif resolution == "2K":
             max_pixel = 2048**2
+        elif resolution == "4K":
+            max_pixel = 4096**2
         else:
-            raise ValueError(f"Unsupported resolution: {resolution}")
+            raise ValueError(f"Unsupported resolution token: {resolution!r}")
         aspect_ratio_val = aspect_ratio_val or 1
         if aspect_ratio_val < 1 / 3 or aspect_ratio_val > 3:
             raise ValueError(f"Aspect ratio value must be between [1/3, 3], got {aspect_ratio_val}")

--- a/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
@@ -101,7 +101,8 @@ class OpenAIImageGenerationClient(T2IBaseClient):
 
         Returns:
             dict:
-                Dictionary with keys: status, output (path), message.
+                On success, keys: status, output (path), message. On failure,
+                keys: status, error_type, error.
         """
         model = model or self.model or global_configs.SN_IMAGE_GEN_MODEL
         if not model:
@@ -298,8 +299,8 @@ class OpenAIImageGenerationClient(T2IBaseClient):
         images: list[tuple[bytes, str]] = []
         data_items: list[dict] = raw_data.get("data") or []
         for item in data_items:
-            encoded: str = item.get("b64_json") or ""
-            if not encoded:
+            encoded = item.get("b64_json")
+            if not isinstance(encoded, str) or not encoded:
                 continue
 
             if encoded.startswith("data:"):

--- a/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/openai_image.py
@@ -165,14 +165,15 @@ class OpenAIImageGenerationClient(T2IBaseClient):
                             details += f"\nIs any of the following environment variable(s) set correctly: {env_names_str}?"
             return {
                 "status": "failed",
-                "error": f"HTTP {exc.code}: {exc.message}",
-                "message": details,
+                "error_type": type(exc).__name__,
+                "error": f"HTTP {exc.code}: {exc.message}" + (f"\n{details}" if details else ""),
             }
         try:
             images = data["images"]
             if not images:
                 return {
                     "status": "failed",
+                    "error_type": "EmptyResponse",
                     "error": "No image generated from the model",
                 }
             image_bytes, mime_type = images[-1]
@@ -187,14 +188,14 @@ class OpenAIImageGenerationClient(T2IBaseClient):
         except httpx.HTTPStatusError as exc:
             return {
                 "status": "failed",
-                "error": f"HTTP {exc.response.status_code}",
-                "message": f"http error: {exc.response.status_code} {exc.response.text}",
+                "error_type": type(exc).__name__,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text}",
             }
         except (httpx.HTTPError, OSError, ValueError) as exc:
             return {
                 "status": "failed",
-                "error": type(exc).__name__,
-                "message": f"request error: {exc}",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
             }
 
     @property

--- a/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
@@ -325,7 +325,13 @@ class SensenovaText2ImageClient(T2IBaseClient):
         elif resolution == "2K":
             buckets = BUCKETS_2K
         else:
-            raise ValueError(f"Unsupported resolution: {resolution!r}. Must be '1K' or '2K'.")
+            # The SenseNova backend only has 1K / 2K pixel buckets. Reject any
+            # other resolution (e.g. 4K) here; the ValueError propagates to the
+            # runner and is returned to the caller as a status=failed JSON.
+            raise ValueError(
+                f"image-size {resolution!r} is not supported by the SenseNova image backend "
+                f"(supported: 1K, 2K)."
+            )
         try:
             ws, _, hs = aspect_ratio.strip().partition(":")
             width = int(ws)

--- a/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
@@ -124,7 +124,8 @@ class SensenovaText2ImageClient(T2IBaseClient):
 
         Returns:
             dict:
-                Dictionary with keys: status, output (path), message.
+                On success, keys: status, output (path), message. On failure,
+                keys: status, error_type, error.
         """
         model = model or self.model or global_configs.SN_IMAGE_GEN_MODEL
         # Normalize image_size to uppercase for NanoBanana API
@@ -364,7 +365,7 @@ class SensenovaText2ImageClient(T2IBaseClient):
         images_urls: list[str] = []
         for item in raw_data.get("data", []):
             url = item.get("url")
-            if url:
+            if isinstance(url, str) and url:
                 images_urls.append(url)
         return {"images_urls": images_urls}
 

--- a/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
@@ -178,14 +178,15 @@ class SensenovaText2ImageClient(T2IBaseClient):
                             details += f"\nIs any of the following environment variable(s) set correctly: {env_names_str}?"
             return {
                 "status": "failed",
-                "error": f"HTTP {exc.code}: {exc.message}",
-                "message": details,
+                "error_type": type(exc).__name__,
+                "error": f"HTTP {exc.code}: {exc.message}" + (f"\n{details}" if details else ""),
             }
         try:
             images_urls: list[str] = data["images_urls"]
             if not images_urls:
                 return {
                     "status": "failed",
+                    "error_type": "EmptyResponse",
                     "error": "No image generated from the model",
                 }
             url = images_urls[-1]
@@ -200,14 +201,14 @@ class SensenovaText2ImageClient(T2IBaseClient):
         except httpx.HTTPStatusError as exc:
             return {
                 "status": "failed",
-                "error": f"HTTP {exc.response.status_code}",
-                "message": f"http error: {exc.response.status_code} {exc.response.text}",
+                "error_type": type(exc).__name__,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text}",
             }
         except (httpx.HTTPError, OSError, ValueError) as exc:
             return {
                 "status": "failed",
-                "error": type(exc).__name__,
-                "message": f"request error: {exc}",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
             }
 
     @property

--- a/skills/sn-image-base/scripts/sn_image_base/utils/httpx_client.py
+++ b/skills/sn-image-base/scripts/sn_image_base/utils/httpx_client.py
@@ -6,7 +6,6 @@ limit check to avoid PoolTimeout and 'Too many open files' under high concurrenc
 
 import contextlib
 import json
-import resource
 from typing import Any
 
 import httpx
@@ -34,6 +33,8 @@ def check_file_descriptor_limit(max_connections: int, margin: int = 200) -> None
         RuntimeError: If soft limit < max_connections + margin.
     """
     try:
+        import resource  # POSIX-only; absent on Windows
+
         soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     except (ImportError, AttributeError, OSError):
         return

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -42,10 +42,15 @@ Features:
 
 | Parameter | Type | Default Value | Description |
 |-----------|------|---------------|-------------|
-| `user_prompt` | string | **Required** | User original request |
-| `max_rounds` | int | `1` | Maximum number of generation rounds |
-| `output_mode` | string | `friendly` | Output mode: friendly / verbose |
-| `prompts_expand_mode` | string | `auto` | expand strategy: auto / force / disable |
+| `user_prompt` | string | **Required** | Original user request. UTF-8 text; may include Markdown, URLs, or structured data. Length bounded only by the underlying LLM context budget. |
+| `max_rounds` | int | `1` | Maximum number of generation rounds. Valid range: `1`–`8`. When `max_rounds=1`, the Step 3 VLM review and the early-termination check are both skipped. |
+| `output_mode` | string | `friendly` | `friendly`: one-line content description + rank=1 single image |
+|               |        |               | `verbose`: full quality ranking + timing stats + all images (ordered by rank) |
+| `prompts_expand_mode` | string | `auto` | `auto`: evaluate `user_prompt` quality first; enter Step 2 expansion only when it falls short |
+|                       |        |          | `force`: skip evaluation, always execute Step 2 expansion |
+|                       |        |          | `disable`: skip Step 2, use `user_prompt` directly as `expanded_prompt` |
+| `aspect_ratio` | string | *inferred* (`16:9`) | Aspect ratio for image generation. Inferred from `user_prompt` (see `references/runtime-parameters.md`). |
+| `image_size` | string | *inferred* (`2k`) | Image size for image generation. Inferred from `user_prompt` (see `references/runtime-parameters.md`). |
 
 ## API Configuration
 
@@ -82,18 +87,53 @@ This skill uses a two-tier agent architecture:
 
 ### Main Agent Workflow
 
-1. Extract `user_prompt`, `max_rounds` (default 1), `output_mode` (default `friendly`), and `prompts_expand_mode` (default `auto`) from user request
+1. **Parameter extraction** from the user request, in three passes:
+   1. **Inline KV directives** — parse tokens of the form `key=value` where `key` ∈ {`max_rounds`, `output_mode`, `prompts_expand_mode`}; strip recognized tokens from the user message, and the remainder becomes `user_prompt`. Example: `"生成一张信息图 max_rounds=3 output_mode=verbose"` → `user_prompt="生成一张信息图"`, `max_rounds=3`, `output_mode=verbose`.
+   2. **Keyword recognition** (case-insensitive, applied to the stripped text) — fill any parameter not yet set by inline KV using the table below:
+
+      | Parameter | Trigger keywords | Resolved value |
+      |-----------|------------------|----------------|
+      | `output_mode` | `verbose`, `详细`, `详尽`, `完整统计` | `verbose` |
+      |               | `friendly`, `简洁`, `精简` | `friendly` |
+      | `max_rounds` | `N 轮`, `N rounds`, `重试 N 次` (parse `N`) | `N`, clamped to `[1, 8]` |
+      | `prompts_expand_mode` | `强制扩写`, `force expand`, `force expansion` | `force` |
+      |                       | `不扩写`, `跳过扩写`, `disable expansion`, `no expand` | `disable` |
+
+   3. **Defaults** — any parameter still unset falls back to `max_rounds=1`, `output_mode=friendly`, `prompts_expand_mode=auto`.
+
+   Precedence: **inline KV > keyword recognition > default**. Values from inline KV are validated against the Input Specification (out-of-range `max_rounds` clamped to `[1, 8]`; unrecognized enum values fall back to default and Main Agent should log the mismatch).
 2. Send uniform preflight message: `"Using sn-infographic skill to generate infographic, please wait..."`
 3. Start Worker Agent (Sub-Agent), passing in complete parameters and working directory
 4. When Worker Agent returns `status=ok` and `need_main_agent_send=true`:
-   - **max_rounds = 1**: Generate a one-sentence description of the image content from `expanded_prompt` in the returned JSON (always present for `status=ok`, see Return Contract), then send the rank=1 single image
-   - **max_rounds > 1, friendly mode**: Generate a one-sentence natural language description based on the rank=1 round's `result` and `violations`, send the evaluation text, then send the rank=1 single image
-   - **max_rounds > 1, verbose mode**: Send complete text summary message, then send all images in rank order to the user
+   - **max_rounds = 1**: Generate the Text Summary (see Output Format → friendly mode for length/language rules) from `expanded_prompt` in the returned JSON (always present for `status=ok`, see Return Contract), send it, then send the rank=1 single image
+   - **max_rounds > 1, friendly mode**: Generate the Text Summary based on the rank=1 round's `result` and `violations`, send it, then send the rank=1 single image
+   - **max_rounds > 1, verbose mode**: Render the verbose template (see Output Format → verbose mode for substitution rules) and send it, then send all images in rank order
 5. If Worker Agent returns `status=error`, report the real `error` field content to the user
 
 ### Worker Agent Workflow
 
-Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expand_mode`, and the working directory of this skill (`SN_IMAGE_INFOG`).
+Worker Agent receives `user_prompt`, `max_rounds`, `prompts_expand_mode`, and the working directory of this skill (`SKILL_DIR`). (`output_mode` stays on the Main Agent side — Worker has no branch that depends on it.)
+
+#### Worker Environment
+
+Variables referenced as `$NAME` in the bash snippets below. Worker must bind each before the step that consumes it.
+
+| Variable | Source | Used by |
+|----------|--------|---------|
+| `USER_PROMPT` | Main Agent input — original user request | Step 1 evaluation; Step 2.0 content analysis |
+| `MAX_ROUNDS` | Main Agent input (default `1`) | Step 3 loop bound; early-termination gate |
+| `PROMPTS_EXPAND_MODE` | Main Agent input (default `auto`) | branches Step 1 |
+| `SKILL_DIR` | Agent runtime resolves the current skill's install path (e.g. `~/.openclaw/skills/sn-infographic`, `~/.hermes/skills/sn-infographic`) | reads `references/*` |
+| `SN_IMAGE_BASE` | Agent runtime resolves by skill name `sn-image-base` in the installed-skill registry | runs `scripts/sn_agent_runner.py` |
+| `TASK_ID` | Step 0 (`date +%Y%m%d_%H%M%S`) | uniqueness token |
+| `TEMP_DIR` | Step 0 (`/tmp/openclaw/sn-infographic/${TASK_ID}`) | scratch dir for all intermediate artifacts |
+| `IMAGE_SIZE` | Step 0 (inferred from `USER_PROMPT`, default `2k`) | `sn-image-generate --image-size` |
+| `ASPECT_RATIO` | Step 0 (inferred from `USER_PROMPT`, default `16:9`) | `sn-image-generate --aspect-ratio` |
+| `EXPANDED_PROMPT` | Step 1 (copy of `USER_PROMPT` when Step 2 is skipped) or Step 2.3 (expanded result) | `sn-image-generate --prompt` |
+| `LAYOUT`, `STYLE` | Step 2.1 selection result (with fallback to `hub-spoke` / `corporate-memphis`) | Step 2.3 system-prompt assembly |
+| `ROUND` | Step 3 loop counter (`for ROUND in $(seq 1 "$MAX_ROUNDS")`) | per-round file naming (`round_${ROUND}.png`) |
+
+**Naming**: `$SKILL_DIR` for own files; `$SN_<SKILL_NAME>` (e.g. `$SN_IMAGE_BASE`) for cross-skill references.
 
 #### Step 0 — Initialization
 
@@ -106,7 +146,7 @@ Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expan
    ```
 
 2. Initialize an empty `rounds` list
-3. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SN_IMAGE_INFOG/references/runtime-parameters.md`
+3. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SKILL_DIR/references/runtime-parameters.md`
 
 #### Step 1 — `prompts_expand_mode` Processing
 
@@ -130,7 +170,7 @@ Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expan
 **`auto` mode**:
 
 1. Call sn-text-optimize for evaluation
-2. Parse JSON, extract `required_results` and `optional_results`
+2. Parse JSON (response schema defined by `$SKILL_DIR/references/evaluation-standard.md`); extract `required_results` and `optional_results`
 3. Determine logic:
    - `required_pass`: All `answer` in `required_results` are `"yes"`
    - `optional_pass`: The number of `answer="yes"` in `optional_results` / total ≥ 0.6
@@ -149,7 +189,7 @@ Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expan
 
 ```bash
 python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
-  --system-prompt-path "$SN_IMAGE_INFOG/references/evaluation-standard.md" \
+  --system-prompt-path "$SKILL_DIR/references/evaluation-standard.md" \
   --user-prompt "$USER_PROMPT" \
   --output-format json
 ```
@@ -160,7 +200,7 @@ python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
 
 ```bash
 ANALYSIS=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
-  --system-prompt-path "$SN_IMAGE_INFOG/references/analysis-framework.md" \
+  --system-prompt-path "$SKILL_DIR/references/analysis-framework.md" \
   --user-prompt "$USER_PROMPT" \
   --output-format json)
 ```
@@ -171,6 +211,8 @@ Save analysis result stdout to `analysis.json` in temporary directory `$TEMP_DIR
 echo "$ANALYSIS" > "$TEMP_DIR/analysis.json"
 ```
 
+Schema: `$SKILL_DIR/references/analysis-framework.md` (defines `data_type`, `tone`, `audience`, and the other fields consumed by Step 2.1 / 2.2).
+
 **2.1 Layout & Style Selection**
 
 1. Read analysis result from temporary directory `$TEMP_DIR/analysis.json`;
@@ -179,12 +221,12 @@ echo "$ANALYSIS" > "$TEMP_DIR/analysis.json"
   ANALYSIS=$(cat "$TEMP_DIR/analysis.json")
   ```
 
-2. Based on `data_type`, `tone`, `audience`, select `layout` and `style` based on the rules in `$SN_IMAGE_INFOG/references/layout-style-selection.md`;
+2. Based on `data_type`, `tone`, `audience`, select `layout` and `style` based on the rules in `$SKILL_DIR/references/layout-style-selection.md`;
 3. Validate the selection by checking the definition files exist; fall back to `hub-spoke` + `corporate-memphis` if missing:
 
   ```bash
-  [ -f "$SN_IMAGE_INFOG/references/layouts/${LAYOUT}.md" ] || LAYOUT=hub-spoke
-  [ -f "$SN_IMAGE_INFOG/references/styles/${STYLE}.md" ] || STYLE=corporate-memphis
+  [ -f "$SKILL_DIR/references/layouts/${LAYOUT}.md" ] || LAYOUT=hub-spoke
+  [ -f "$SKILL_DIR/references/styles/${STYLE}.md" ] || STYLE=corporate-memphis
   ```
 
 4. Save selection result to temporary directory: `$TEMP_DIR/layout-style.json`;
@@ -205,7 +247,7 @@ Read analysis result and structured content template, convert `user_prompt` into
 ```bash
 ANALYSIS=$(cat "$TEMP_DIR/analysis.json")
 LAYOUT_STYLE=$(cat "$TEMP_DIR/layout-style.json")
-STRUCTURED_CONTENT_TEMPLATE=$(cat "$SN_IMAGE_INFOG/references/structured-content-template.md")
+STRUCTURED_CONTENT_TEMPLATE=$(cat "$SKILL_DIR/references/structured-content-template.md")
 ```
 
 Follow the three phases defined in the template (High-Level Outline → Section Development → Data Integrity Check),
@@ -216,6 +258,8 @@ cat > "$TEMP_DIR/structured-content.md" << 'EOF'
 <Content generated based on structured-content-template.md format>
 EOF
 ```
+
+Structure: `$SKILL_DIR/references/structured-content-template.md`.
 
 **Rules**: All data must be preserved exactly. Do not rewrite. Do not add information that is not in the source.
 
@@ -228,13 +272,13 @@ LAYOUT=$(jq -r '.layout' "$TEMP_DIR/layout-style.json")
 STYLE=$(jq -r '.style' "$TEMP_DIR/layout-style.json")
 
 {
-  cat "$SN_IMAGE_INFOG/references/prompts-expand-system.md"
+  cat "$SKILL_DIR/references/prompts-expand-system.md"
   printf '\n\n---\n\n## Selected Layout: %s\n\n' "$LAYOUT"
-  cat "$SN_IMAGE_INFOG/references/layouts/${LAYOUT}.md"
+  cat "$SKILL_DIR/references/layouts/${LAYOUT}.md"
   printf '\n\n---\n\n## Selected Style: %s\n\n' "$STYLE"
-  cat "$SN_IMAGE_INFOG/references/styles/${STYLE}.md"
+  cat "$SKILL_DIR/references/styles/${STYLE}.md"
   printf '\n\n---\n\n## Output Template Reference\n\n'
-  cat "$SN_IMAGE_INFOG/references/base-prompt.md"
+  cat "$SKILL_DIR/references/base-prompt.md"
 } > "$TEMP_DIR/expand-system-prompt.md"
 ```
 
@@ -252,6 +296,8 @@ Parse JSON stdout, extract `result` field as `expanded_prompt`, and write to tem
 ```bash
 echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
 ```
+
+`expanded-prompt.txt`: single UTF-8 string, passed verbatim to `sn-image-generate --prompt` in Step 3.
 
 If parsing fails or truncation is suspected (the returned content is incomplete), Worker Agent must immediately return the Error Flow JSON (`status=error` with the real error message) to Main Agent and terminate — Worker is not allowed to message the user directly (see Responsibility Boundaries).
 
@@ -279,22 +325,25 @@ python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-image-generate \
 
 **Review Image** (only executed when `max_rounds > 1`):
 
-VLM configuration requirements:
-
-- When `max_rounds > 1`, call VLM for review
-- Select VLM model from OpenClaw configuration as parameter for image recognition
-- If no suitable VLM model exists in OpenClaw configuration: Worker Agent returns the Error Flow JSON (`status=error`) with an `error` message stating the current parameter combination cannot be executed and recommending the user add a VLM configuration or set `max_rounds=1` to avoid VLM calls. Main Agent surfaces this message to the user.
-- If VLM call times out or fails: do not fallback; Worker returns the Error Flow JSON with the real error in the `error` field (no direct user-facing messages from Worker).
+- If no VLM model is configured: return Error Flow JSON suggesting the user add a VLM configuration or set `max_rounds=1`.
+- If the VLM call fails/times out: no fallback; return Error Flow JSON with the real error.
 
 ```bash
 python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-image-recognize \
-  --system-prompt-path "$SN_IMAGE_INFOG/references/prompts-critic-system.md" \
+  --system-prompt-path "$SKILL_DIR/references/prompts-critic-system.md" \
   --user-prompt "Evaluate the diagram in the image against the rules. Output your assessment." \
   --images "$TEMP_DIR/round_${ROUND}.png" \
   --output-format json
 ```
 
-System prompt comes from `references/prompts-critic-system.md`, user prompt is provided directly.
+**Map VLM response into the per-round record** (the VLM response schema is defined in `$SKILL_DIR/references/prompts-critic-system.md`; each violation is a four-field object):
+
+- `vlm.result` → `rounds[i].result` (verbatim — `"PASS"` or `"FAIL"`)
+- `vlm.violations` → `rounds[i].violations` (passthrough verbatim — array of `{ rule_id, rule_name, detail, revised_description }` objects)
+- `len(vlm.violations)` → `rounds[i].violations_count`
+- `vlm.reasoning` → `rounds[i].reasoning` (verbatim string passthrough)
+
+When `max_rounds=1` (no VLM call), default the round record to `result="PASS"`, `violations=[]`, `violations_count=0`, `reasoning=""`.
 
 **Save Round Result**：
 
@@ -303,17 +352,22 @@ System prompt comes from `references/prompts-critic-system.md`, user prompt is p
   "round": 1,
   "image": "$TEMP_DIR/round_1.png",
   "result": "PASS|FAIL",
-  "violations_count": 0,
-  "violations": [],
-  "reasoning": "<Reasoning process, empty string when max_rounds=1>",
+  "violations_count": 1,
+  "violations": [
+    {
+      "rule_id": "5",
+      "rule_name": "Illegible Text",
+      "detail": "<offending element description>",
+      "revised_description": "<suggested fix per the prompts-critic-system.md standards>"
+    }
+  ],
+  "reasoning": "<VLM reasoning, or \"\" when max_rounds=1>",
   "timing": {
     "image_generation": { "elapsed_seconds": 12.34, "model": "sn_image_model" },
     "vlm_review": { "elapsed_seconds": 5.67, "model": "sensenova-6.7-flash-lite" }
   }
 }
 ```
-
-Note: `elapsed_seconds` is read from the `--output-format json` return of each CLI call; `image_generation.model` is fixed to the hardcoded placeholder `"sn_image_model"` (sn-image-generate does not return the model field); `vlm_review.model` is read from the JSON return of sn-image-recognize. `timing.vlm_review` is omitted when `max_rounds=1`.
 
 **Early Termination Check** (only executed when `max_rounds > 1`):
 
@@ -328,14 +382,20 @@ Sort images by `violations_count` ascending + `round` ascending, return structur
 
 After Worker Agent completes, its last message must be and only be the following JSON string (bare JSON, no code fences, no preceding or trailing text).
 
+**Notation in the examples below:**
+
+- `<...>` — documentation placeholder; replace with the real value at runtime.
+- `A|B` — one of the listed literals; the returned JSON must contain exactly one of them (e.g. `"result": "PASS"` or `"result": "FAIL"`, never the literal string `"PASS|FAIL"`).
+- `$VAR` — must be expanded to the resolved value before serialization. For example, `"image": "$TEMP_DIR/round_1.png"` in the schema must be returned as the absolute path actually written by Step 3 (e.g. `"/tmp/openclaw/sn-infographic/20260521_120000/round_1.png"`), never the literal `"$TEMP_DIR/round_1.png"`.
+- Conditional fields — every field whose Rules entry says "omitted when …" must be physically absent from the JSON in that case, not present-with-`null`.
+
 **Normal Flow:**
 
 ```json
 {
   "status": "ok",
   "need_main_agent_send": true,
-  "output_mode": "friendly|verbose",
-  "expanded_prompt": "<always present in status=ok responses regardless of output_mode; value is original user_prompt when prompts_expand_skipped=true, otherwise the expanded result from Step 2.3>",
+  "expanded_prompt": "<original user_prompt if prompts_expand_skipped, else expanded result from Step 2.3>",
   "prompts_expand_skipped": true,
   "early_terminated": true,
   "timing": {
@@ -349,9 +409,16 @@ After Worker Agent completes, its last message must be and only be the following
       "round": 1,
       "image": "$TEMP_DIR/round_1.png",
       "result": "PASS|FAIL",
-      "violations_count": 0,
-      "violations": [],
-      "reasoning": "<Reasoning process, empty string when max_rounds=1>",
+      "violations_count": 1,
+      "violations": [
+        {
+          "rule_id": "5",
+          "rule_name": "Illegible Text",
+          "detail": "<offending element description>",
+          "revised_description": "<suggested fix>"
+        }
+      ],
+      "reasoning": "<VLM reasoning, or \"\" when max_rounds=1>",
       "timing": {
         "image_generation": { "elapsed_seconds": 12.34, "model": "sn_image_model" },
         "vlm_review": { "elapsed_seconds": 5.67, "model": "sensenova-6.7-flash-lite" }
@@ -372,37 +439,35 @@ After Worker Agent completes, its last message must be and only be the following
 
 **Rules:**
 
-- `status=ok` must contain `need_main_agent_send: true`
-- `expanded_prompt` is always present in `status=ok` responses (regardless of `output_mode`); value is the original `user_prompt` when `prompts_expand_skipped=true`, otherwise the expanded prompt produced in Step 2.3
-- `prompts_expand_skipped` is present (value `true`) **only** when Step 2 is skipped — covers two cases:
-  - `prompts_expand_mode=disable`
-  - `prompts_expand_mode=auto` and Step 1 evaluation passes
-  The field is **omitted** (semantically `false`) in all other cases, i.e. `prompts_expand_mode=force` or `auto` with evaluation failing
-- `early_terminated` must contain when early termination (value is `true`), omitted when normal execution completes
-- `violations` is an array of strings, from review results
-- `reasoning` is an empty string when `max_rounds=1`
-- Top-level `timing` contains:
-  - `total_elapsed_seconds`: Worker Agent's wall time from Step 0 to returning JSON, calculated by Worker Agent itself
-  - `prompt_detection`: Step 1 evaluation call; **present only when `prompts_expand_mode=auto`** (omitted under `disable` and `force`, neither of which invokes the evaluation)
-  - `content_analysis`: Step 2.0 content analysis call; **omitted when Step 2 is skipped** (i.e. `prompts_expand_skipped=true`)
-  - `prompt_expand`: Step 2.3 prompt expansion call; **omitted when Step 2 is skipped** (i.e. `prompts_expand_skipped=true`)
-  - Each of the three sub-objects contains `elapsed_seconds` and `model` (read from the sn-text-optimize JSON return)
-- `rounds[].timing.image_generation.model` is fixed to the hardcoded placeholder `"sn_image_model"`
-- `rounds[].timing.vlm_review` is omitted when `max_rounds=1`
+- `status=ok` must contain `need_main_agent_send: true`.
+- `expanded_prompt`: always present in `status=ok`; value is original `user_prompt` when `prompts_expand_skipped=true`, else the Step 2.3 result.
+- `prompts_expand_skipped`: present (`true`) only when Step 2 is skipped (`prompts_expand_mode=disable`, or `auto` with passing evaluation); omitted otherwise.
+- `early_terminated`: present (`true`) only when Step 3 exited the loop early via a `PASS`; omitted otherwise (including all `max_rounds=1` runs).
+- `violations`: array of objects from the VLM response, schema `$SKILL_DIR/references/prompts-critic-system.md` (`rule_id`, `rule_name`, `detail`, `revised_description`). `[]` when `result=PASS` or `max_rounds=1`.
+- `violations_count`: `len(violations)`; `0` when `max_rounds=1`.
+- `reasoning`: VLM `reasoning` field verbatim; `""` when `max_rounds=1`.
+- When `max_rounds=1`, the single round's `result` defaults to `"PASS"` (image delivered without VLM check).
+- Top-level `timing`:
+  - `total_elapsed_seconds`: Worker wall time from Step 0 to JSON return.
+  - `prompt_detection`: `{elapsed_seconds, model}` from Step 1 evaluation. Present only when `prompts_expand_mode=auto`.
+  - `content_analysis`: `{elapsed_seconds, model}` from Step 2.0. Omitted when `prompts_expand_skipped=true`.
+  - `prompt_expand`: `{elapsed_seconds, model}` from Step 2.3. Omitted when `prompts_expand_skipped=true`.
+- `rounds[].timing.image_generation.model`: hardcoded `"sn_image_model"` (sn-image-generate returns no model field).
+- `rounds[].timing.vlm_review`: omitted when `max_rounds=1`.
 
 ## Output Format
 
 ### friendly mode (default)
 
-**Text Summary:**
+**Text Summary** — a one-sentence description generated by Main Agent. Length: **≤ 50 chars/字** regardless of language (1 Chinese character = 1 unit, 1 ASCII character = 1 unit). Language: follow the dominant language of `user_prompt` (predominantly Chinese → output Chinese; otherwise → output English).
 
-- **when `max_rounds = 1`**: Generate a one-sentence description of the image content based on `expanded_prompt`,不超过50字
-- **when `max_rounds > 1`**: Generate a one-sentence description of the image content based on `result` and `violations`,不超过50字：
-  - `result=PASS`: Describe in a positive tone
-  - `result=FAIL` (1-2 violations): Gently point out specific issues
-  - `result=FAIL` (3 or more): Objectively summarize the main issues
+- **when `max_rounds = 1`**: derive the description from `expanded_prompt` (focus on what the infographic depicts).
+- **when `max_rounds > 1`**: derive the description from the rank=1 round's `result` and `violations`:
+  - `result=PASS`: positive tone.
+  - `result=FAIL` (1–2 violations): briefly point out the specific issues.
+  - `result=FAIL` (≥ 3 violations): objectively summarize the main issues.
 
-**Image**: rank=1 best single image
+**Image**: rank=1 single image.
 
 ### verbose mode
 
@@ -420,6 +485,22 @@ Time statistics: Total <total>s | Prompt evaluation <t>s | Content analysis <t>s
 ---
 Images (sent in rank order)
 ```
+
+**Substitution rules:**
+
+| Placeholder | Rule |
+|-------------|------|
+| `[expanded \| not expanded, using original prompt]` | `not expanded, using original prompt` when `prompts_expand_skipped=true` is present in the Return JSON; otherwise `expanded`. |
+| `<expanded_prompt>` | The `expanded_prompt` field from the Return JSON, verbatim. |
+| `#k round=<n> result=… violations=…` | One line per entry in `rounds[]`, in rank order (`k = 1..len(rounds)`); `<n>` is `rounds[i].round`. |
+| `[early terminated]` | Append **only** to the round that actually triggered early termination (i.e. the `result=PASS` round that cut the loop). Omit on all other lines. If `early_terminated` is absent from the Return JSON, the tag never appears. |
+| `Total <total>s` | `timing.total_elapsed_seconds`. Always present. |
+| `Prompt evaluation <t>s` | `timing.prompt_detection.elapsed_seconds`. **Omit this `\| Prompt evaluation …` segment entirely** when `prompt_detection` is absent from the Return JSON. |
+| `Content analysis <t>s` | `timing.content_analysis.elapsed_seconds`. Omit the segment entirely when absent. |
+| `Prompt expansion <t>s` | `timing.prompt_expand.elapsed_seconds`. Omit the segment entirely when absent. |
+| `Image generation <t>s×<n> rounds` | `<t>` = sum of `rounds[].timing.image_generation.elapsed_seconds`; `<n>` = `len(rounds)`. |
+| `VLM review <t>s×<n> rounds` | `<t>` = sum of `rounds[].timing.vlm_review.elapsed_seconds` (only over rounds where the field exists); `<n>` = number of rounds with VLM review. Omit the segment entirely when `max_rounds=1` (no VLM review occurred). |
+| `Images (sent in rank order)` | Section header; image delivery itself follows the channel conventions of the host runtime. |
 
 ## Call Relationship
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -97,10 +97,16 @@ Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expan
 
 #### Step 0 — Initialization
 
-1. Generate `task_id` (using timestamp, format `YYYYMMDD_HHMMSS`)
-2. Create a uniform temporary directory: `/tmp/openclaw/sn-infographic/<task_id>/` as `TEMP_DIR`
-3. Initialize an empty `rounds` list
-4. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SKILL_DIR/references/runtime-parameters.md`
+1. Generate `task_id` (timestamp, format `YYYYMMDD_HHMMSS`) and create the uniform temporary directory `/tmp/openclaw/sn-infographic/<task_id>/` as `TEMP_DIR`. `TEMP_DIR` must exist before any subsequent step writes to it:
+
+   ```bash
+   TASK_ID=$(date +%Y%m%d_%H%M%S)
+   TEMP_DIR="/tmp/openclaw/sn-infographic/${TASK_ID}"
+   mkdir -p "$TEMP_DIR"
+   ```
+
+2. Initialize an empty `rounds` list
+3. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SN_IMAGE_INFOG/references/runtime-parameters.md`
 
 #### Step 1 — `prompts_expand_mode` Processing
 
@@ -142,7 +148,7 @@ Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expan
 
 ```bash
 python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
-  --system-prompt-path "$SKILL_DIR/references/evaluation-standard.md" \
+  --system-prompt-path "$SN_IMAGE_INFOG/references/evaluation-standard.md" \
   --user-prompt "$USER_PROMPT" \
   --output-format json
 ```
@@ -153,7 +159,7 @@ python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
 
 ```bash
 ANALYSIS=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
-  --system-prompt-path "$SKILL_DIR/references/analysis-framework.md" \
+  --system-prompt-path "$SN_IMAGE_INFOG/references/analysis-framework.md" \
   --user-prompt "$USER_PROMPT" \
   --output-format json)
 ```
@@ -172,15 +178,13 @@ echo "$ANALYSIS" > "$TEMP_DIR/analysis.json"
   ANALYSIS=$(cat "$TEMP_DIR/analysis.json")
   ```
 
-2. Based on `data_type`, `tone`, `audience`, select `layout` and `style` based on the rules in `$SKILL_DIR/references/layout-style-selection.md`;
-3. Read layout/style definition files:
+2. Based on `data_type`, `tone`, `audience`, select `layout` and `style` based on the rules in `$SN_IMAGE_INFOG/references/layout-style-selection.md`;
+3. Validate the selection by checking the definition files exist; fall back to `hub-spoke` + `corporate-memphis` if missing:
 
   ```bash
-  LAYOUT_DEF=$(cat "$SKILL_DIR/references/layouts/<layout>.md")
-  STYLE_DEF=$(cat "$SKILL_DIR/references/styles/<style>.md")
+  [ -f "$SN_IMAGE_INFOG/references/layouts/${LAYOUT}.md" ] || LAYOUT=hub-spoke
+  [ -f "$SN_IMAGE_INFOG/references/styles/${STYLE}.md" ] || STYLE=corporate-memphis
   ```
-
-  If file does not exist, fallback to `hub-spoke` + `corporate-memphis`.
 
 4. Save selection result to temporary directory: `$TEMP_DIR/layout-style.json`;
 
@@ -200,7 +204,7 @@ Read analysis result and structured content template, convert `user_prompt` into
 ```bash
 ANALYSIS=$(cat "$TEMP_DIR/analysis.json")
 LAYOUT_STYLE=$(cat "$TEMP_DIR/layout-style.json")
-STRUCTURED_CONTENT_TEMPLATE=$(cat "$SKILL_DIR/references/structured-content-template.md")
+STRUCTURED_CONTENT_TEMPLATE=$(cat "$SN_IMAGE_INFOG/references/structured-content-template.md")
 ```
 
 Follow the three phases defined in the template (High-Level Outline → Section Development → Data Integrity Check),
@@ -216,45 +220,29 @@ EOF
 
 **2.3 Prompt Expansion** (using `sn-image-base`'s `sn-text-optimize` tool):
 
-Read structured content and layout/style selection from temporary directory, dynamically concatenate system prompt, and write to temporary file:
+Read layout/style selection, then assemble the system prompt by **direct file concatenation** (do not use heredocs — layout/style files contain backticks and `$(...)` that an unquoted heredoc body would execute):
 
 ```bash
-STRUCTURED_CONTENT=$(cat "$TEMP_DIR/structured-content.md")
-LAYOUT_STYLE=$(cat "$TEMP_DIR/layout-style.json")
-LAYOUT=$(echo "$LAYOUT_STYLE" | jq -r '.layout')
-STYLE=$(echo "$LAYOUT_STYLE" | jq -r '.style')
-LAYOUT_DEF=$(cat "$SKILL_DIR/references/layouts/${LAYOUT}.md")
-STYLE_DEF=$(cat "$SKILL_DIR/references/styles/${STYLE}.md")
+LAYOUT=$(jq -r '.layout' "$TEMP_DIR/layout-style.json")
+STYLE=$(jq -r '.style' "$TEMP_DIR/layout-style.json")
 
-cat > "$TEMP_DIR/expand-system-prompt.md" << EOF
-$(cat "$SKILL_DIR/references/prompts-expand-system.md")
-
----
-
-## Selected Layout: $LAYOUT
-
-$LAYOUT_DEF
-
----
-
-## Selected Style: $STYLE
-
-$STYLE_DEF
-
----
-
-## Output Template Reference
-
-$(cat "$SKILL_DIR/references/base-prompt.md")
-EOF
+{
+  cat "$SN_IMAGE_INFOG/references/prompts-expand-system.md"
+  printf '\n\n---\n\n## Selected Layout: %s\n\n' "$LAYOUT"
+  cat "$SN_IMAGE_INFOG/references/layouts/${LAYOUT}.md"
+  printf '\n\n---\n\n## Selected Style: %s\n\n' "$STYLE"
+  cat "$SN_IMAGE_INFOG/references/styles/${STYLE}.md"
+  printf '\n\n---\n\n## Output Template Reference\n\n'
+  cat "$SN_IMAGE_INFOG/references/base-prompt.md"
+} > "$TEMP_DIR/expand-system-prompt.md"
 ```
 
-Use the content of `structured-content.md` as user-prompt, read system prompt from temporary file and call sn-text-optimize:
+Use the content of `structured-content.md` as user-prompt (passed via `--user-prompt-path` to avoid argv-length and quoting issues), read system prompt from temporary file and call sn-text-optimize:
 
 ```bash
 python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
   --system-prompt-path "$TEMP_DIR/expand-system-prompt.md" \
-  --user-prompt "$STRUCTURED_CONTENT" \
+  --user-prompt-path "$TEMP_DIR/structured-content.md" \
   --output-format json
 ```
 
@@ -264,11 +252,18 @@ Parse JSON stdout, extract `result` field as `expanded_prompt`, and write to tem
 echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
 ```
 
-If parsing fails or truncation is suspected (the returned content is incomplete), notify the user and terminate the workflow.
+If parsing fails or truncation is suspected (the returned content is incomplete), Worker Agent must immediately return the Error Flow JSON (`status=error` with the real error message) to Main Agent and terminate — Worker is not allowed to message the user directly (see Responsibility Boundaries).
 
 #### Step 3 — Image Generation Loop
 
-Execute `round` from `1` to `max_rounds` sequentially:
+Execute round `ROUND` from `1` to `max_rounds` sequentially. Inside each iteration set the shell variable `ROUND` to the current round number, and use `${ROUND}` in every path so successive rounds do not overwrite each other:
+
+```bash
+for ROUND in $(seq 1 "$MAX_ROUNDS"); do
+  # the Generate Image / Review Image / Save Round Result blocks below run inside this loop body
+  :
+done
+```
 
 **Generate Image** (using `sn-image-base`'s `sn-image-generate` tool):
 
@@ -277,7 +272,7 @@ python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-image-generate \
   --prompt "$EXPANDED_PROMPT" \
   --image-size "$IMAGE_SIZE" \
   --aspect-ratio "$ASPECT_RATIO" \
-  --save-path "$TEMP_DIR/round_<N>.png" \
+  --save-path "$TEMP_DIR/round_${ROUND}.png" \
   -o json
 ```
 
@@ -287,16 +282,14 @@ VLM configuration requirements:
 
 - When `max_rounds > 1`, call VLM for review
 - Select VLM model from OpenClaw configuration as parameter for image recognition
-- If no suitable VLM model exists in OpenClaw configuration:
-  - Notify user that current parameter combination cannot be executed
-  - Suggest adding VLM configuration or changing max_rounds to 1 to avoid VLM calls
-- If VLM call times out or fails: do not fallback, report the real error directly
+- If no suitable VLM model exists in OpenClaw configuration: Worker Agent returns the Error Flow JSON (`status=error`) with an `error` message stating the current parameter combination cannot be executed and recommending the user add a VLM configuration or set `max_rounds=1` to avoid VLM calls. Main Agent surfaces this message to the user.
+- If VLM call times out or fails: do not fallback; Worker returns the Error Flow JSON with the real error in the `error` field (no direct user-facing messages from Worker).
 
 ```bash
 python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-image-recognize \
   --system-prompt-path "$SN_IMAGE_INFOG/references/prompts-critic-system.md" \
   --user-prompt "Evaluate the diagram in the image against the rules. Output your assessment." \
-  --images "$TEMP_DIR/round_<N>.png" \
+  --images "$TEMP_DIR/round_${ROUND}.png" \
   --output-format json
 ```
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -50,9 +50,9 @@ Features:
 |                       |        |          | `force`: skip evaluation, always execute Step 2 expansion |
 |                       |        |          | `disable`: skip Step 2, use `user_prompt` directly as `expanded_prompt` |
 | `aspect_ratio` | string | *inferred* (`16:9`) | Set by **Main Agent** when the user states an explicit supported ratio (e.g. `16:9` / `9:16`, optionally via `宽高比` / `画面比例` / `aspect ratio`); otherwise left unset and the **Worker** infers it in Step 0 from `user_prompt` (orientation / scene cues) per `references/runtime-parameters.md`. |
-| `image_size` | string | *inferred* (`2k`) | **Derived, not user-set.** The Worker infers it in Step 0 from `user_prompt` (`1k` only when the user explicitly asks for a cheaper / faster / smaller draft, else `2k`) per `references/runtime-parameters.md`; there is no inline-KV or keyword directive for it. |
+| `image_size` | string | *inferred* (`2k`) | Set by **Main Agent** when the user states an explicit size (`2k` / `4k`); otherwise the **Worker** infers it in Step 0 (currently a single option, `2k`). `4k` is forwarded to the model and may be rejected (e.g. sensenova) → surfaced as an error. |
 
-> **Who extracts what:** Main Agent parameter extraction resolves `max_rounds`, `output_mode`, `prompts_expand_mode`, and `aspect_ratio` (only when the user gives an explicit ratio). `image_size`, and `aspect_ratio` without an explicit value, are inferred by the Worker in Step 0.
+> **Who extracts what:** Main Agent parameter extraction resolves `max_rounds`, `output_mode`, `prompts_expand_mode`, and `aspect_ratio` / `image_size` (each only when the user gives an explicit value). `aspect_ratio` and `image_size` without an explicit value are inferred by the Worker in Step 0.
 
 ## API Configuration
 
@@ -90,7 +90,7 @@ This skill uses a two-tier agent architecture:
 ### Main Agent Workflow
 
 1. **Parameter extraction** from the user request, in three passes:
-   1. **Inline KV directives** — parse tokens of the form `key=value` where `key` ∈ {`max_rounds`, `output_mode`, `prompts_expand_mode`, `aspect_ratio`}; strip recognized tokens from the user message, and the remainder becomes `user_prompt`. Example: `"生成一张信息图 max_rounds=3 output_mode=verbose"` → `user_prompt="生成一张信息图"`, `max_rounds=3`, `output_mode=verbose`.
+   1. **Inline KV directives** — parse tokens of the form `key=value` where `key` ∈ {`max_rounds`, `output_mode`, `prompts_expand_mode`, `aspect_ratio`, `image_size`}; strip recognized tokens from the user message, and the remainder becomes `user_prompt`. Example: `"生成一张信息图 max_rounds=3 output_mode=verbose"` → `user_prompt="生成一张信息图"`, `max_rounds=3`, `output_mode=verbose`.
    2. **Keyword recognition** (case-insensitive, applied to the stripped text) — fill any parameter not yet set by inline KV using the table below:
 
       | Parameter | Trigger keywords | Resolved value |
@@ -101,8 +101,9 @@ This skill uses a two-tier agent architecture:
       | `prompts_expand_mode` | `强制扩写`, `force expand`, `force expansion` | `force` |
       |                       | `不扩写`, `跳过扩写`, `disable expansion`, `no expand` | `disable` |
       | `aspect_ratio` | an explicit supported ratio (`16:9` `9:16` `4:3` `3:4` `1:1` `2:3` `3:2` `4:5` `5:4` `21:9` `9:21`), with or without a `宽高比` / `画面比例` / `比例` / `aspect ratio` lead-in | that ratio (validated against the supported set in `runtime-parameters.md`; unsupported value → leave unset for Worker inference) |
+      | `image_size` | an explicit supported size (`2k` `4k`), with or without an `image_size` / `分辨率` / `清晰度` / `image size` lead-in | that size (vague quality words like `高清` / `超清` do **not** count); unsupported value → leave unset for Worker inference |
 
-   3. **Defaults** — any parameter still unset falls back to `max_rounds=1`, `output_mode=friendly`, `prompts_expand_mode=auto`. `aspect_ratio` has **no** Main-Agent default: when no explicit ratio is detected it is left unset for the Worker to infer in Step 0.
+   3. **Defaults** — any parameter still unset falls back to `max_rounds=1`, `output_mode=friendly`, `prompts_expand_mode=auto`. `aspect_ratio` and `image_size` have **no** Main-Agent default: when no explicit value is detected they are left unset for the Worker to infer in Step 0.
 
    Precedence: **inline KV > keyword recognition > default**. Values from inline KV are validated against the Input Specification (out-of-range `max_rounds` clamped to `[1, 8]`; unrecognized enum values fall back to default and Main Agent should log the mismatch).
 2. Send uniform preflight message: `"Using sn-infographic skill to generate infographic, please wait..."`
@@ -115,7 +116,7 @@ This skill uses a two-tier agent architecture:
 
 ### Worker Agent Workflow
 
-Worker Agent receives `user_prompt`, `max_rounds`, `prompts_expand_mode`, an optional `aspect_ratio` (set only when the user gave an explicit ratio), and the working directory of this skill (`SKILL_DIR`). (`output_mode` stays on the Main Agent side — Worker has no branch that depends on it.)
+Worker Agent receives `user_prompt`, `max_rounds`, `prompts_expand_mode`, an optional `aspect_ratio` and `image_size` (each set only when the user gave an explicit value), and the working directory of this skill (`SKILL_DIR`). (`output_mode` stays on the Main Agent side — Worker has no branch that depends on it.)
 
 #### Worker Environment
 
@@ -130,7 +131,7 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 | `SN_IMAGE_BASE` | Agent runtime resolves by skill name `sn-image-base` in the installed-skill registry | runs `scripts/sn_agent_runner.py` |
 | `TASK_ID` | Step 0 (`date +%Y%m%d_%H%M%S`) | uniqueness token |
 | `TEMP_DIR` | Step 0 (`/tmp/openclaw/sn-infographic/${TASK_ID}`) | scratch dir for all intermediate artifacts |
-| `IMAGE_SIZE` | Step 0 (inferred from `USER_PROMPT`, default `2k`) | `sn-image-generate --image-size` |
+| `IMAGE_SIZE` | Main Agent input when the user stated an explicit size, else Step 0 inference from `USER_PROMPT` (single option, `2k`) | `sn-image-generate --image-size` |
 | `ASPECT_RATIO` | Main Agent input when the user stated an explicit ratio, else Step 0 inference from `USER_PROMPT` (default `16:9`) | `sn-image-generate --aspect-ratio` |
 | `EXPANDED_PROMPT` | Step 1 (copy of `USER_PROMPT` when Step 2 is skipped) or Step 2.3 (expanded result) | `sn-image-generate --prompt` |
 | `LAYOUT`, `STYLE` | Step 2.1 selection result (with fallback to `hub-spoke` / `corporate-memphis`) | Step 2.3 system-prompt assembly |
@@ -151,7 +152,7 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
    ```
 
 2. Initialize an empty `rounds` list
-3. Resolve `aspect_ratio`: if the Main Agent passed an explicit `aspect_ratio`, use it as-is (assign to `ASPECT_RATIO`); otherwise infer it (default `16:9`) from `user_prompt`. Always infer `image_size` (default `2k`) from `user_prompt`. Both follow the rules in `$SKILL_DIR/references/runtime-parameters.md`.
+3. Resolve `aspect_ratio` and `image_size` (bind to `ASPECT_RATIO` / `IMAGE_SIZE`): use the explicit Main Agent value when present, else infer from `user_prompt` per `$SKILL_DIR/references/runtime-parameters.md`. Defaults: `aspect_ratio` → `16:9`; `image_size` inference currently has a single option, `2k`.
 
 #### Step 1 — Decide whether to rewrite the image prompt (always runs)
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -220,7 +220,7 @@ ANALYSIS_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-o
   --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
 
-First reject a failed runner envelope, then extract the inner analysis JSON from `.result` and save it to `$TEMP_DIR/analysis.json` (the **inner** JSON, not the envelope, so Step 2.1 can `jq` `data_type` / `tone` / `audience` directly). If the envelope `.status` is not `ok`, or `extract_json.py` exits non-zero, return the Error Flow JSON (`status=error`) carrying the envelope's `.error` to Main Agent and terminate.
+Save the **inner** analysis JSON from `.result` (not the envelope, so Step 2.1 can `jq` `data_type` / `tone` / `audience` directly) to `$TEMP_DIR/analysis.json`. The guard below rejects a failed envelope first (status not `ok` or `extract_json.py` non-zero → Error Flow with `.error`):
 
 ```bash
 # A failed runner envelope (status != ok) has no .result → return Error Flow.
@@ -330,7 +330,7 @@ echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
 
 `expanded-prompt.txt`: single UTF-8 string, passed verbatim to `sn-image-generate --prompt` in Step 3.
 
-If the envelope status is not `ok`, parsing fails, or truncation is suspected (the returned content is incomplete), Worker Agent must immediately return the Error Flow JSON (`status=error` with the real error message — use the envelope's `.error` when present) to Main Agent and terminate — Worker is not allowed to message the user directly (see Responsibility Boundaries).
+Beyond the status guard above, if parsing fails or truncation is suspected (the returned content is incomplete), the Worker must likewise return the Error Flow JSON (`status=error`, real message) and terminate — it must not message the user directly (see Responsibility Boundaries).
 
 #### Step 3 — Image Generation Loop
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -150,60 +150,59 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 2. Initialize an empty `rounds` list
 3. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SKILL_DIR/references/runtime-parameters.md`
 
-#### Step 1 — `prompts_expand_mode` Processing
+#### Step 1 — Expansion Gate (mandatory; decides whether Step 2 runs)
 
-**`disable` mode**:
+This step **always runs**. It produces the gate decision `should_expand` and, whenever Step 2 is skipped, sets `EXPANDED_PROMPT` and records `prompts_expand_skipped = true`.
 
-- Skip expand, directly use `user_prompt` as `expanded_prompt`
-- Assign variable and write to temporary directory:
+`PROMPTS_EXPAND_MODE` here is the **already-resolved input** handed over by the Main Agent — Step 1 *acts on* it, it does **not** re-parse the user request. Resolving the mode value (Main Agent parameter extraction) and running this gate are two different jobs: completing the former does **not** complete Step 1. **Do not skip this step**; in `auto` mode the evaluation call below is mandatory — never infer `should_expand` from the prompt's apparent quality.
 
-  ```bash
-  EXPANDED_PROMPT="$USER_PROMPT"
-  echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
-  ```
+Only **Step 2 (expansion)** is ever skipped, and only when this gate decides so. The branch depends on `PROMPTS_EXPAND_MODE`:
 
-- Record `prompts_expand_skipped = true`
+**`auto` mode** (default):
 
-**`force` mode**:
+1. Run the evaluation call (mandatory). The inner evaluation JSON lives inside `.result`; its schema is `$SKILL_DIR/references/evaluation-standard.md` (`required_results`, `optional_results`).
 
-- Skip evaluation entirely, always execute Step 2 (expansion is mandatory)
-- `prompts_expand_skipped` is **not** recorded — the field appears in the Return JSON only when Step 2 is skipped (see Return Contract rules)
+   ```bash
+   EVAL_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
+     --system-prompt-path "$SKILL_DIR/references/evaluation-standard.md" \
+     --user-prompt "$USER_PROMPT" \
+     --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 
-**`auto` mode**:
+   # A failed runner envelope (status != ok) carries no .result.
+   EVAL_STATUS=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.status')
 
-1. Call sn-text-optimize for evaluation (see **Evaluation Call** below)
-2. Parse the inner evaluation JSON via `extract_json.py` (response schema defined by `$SKILL_DIR/references/evaluation-standard.md`); extract `required_results` and `optional_results`
-3. Determine logic:
-   - `required_pass`: All `answer` in `required_results` are `"yes"`
-   - `optional_pass`: The number of `answer="yes"` in `optional_results` / total ≥ 0.6
+   EVAL=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.result' \
+     | python "$SN_IMAGE_BASE/scripts/extract_json.py")
+   ```
+
+2. Decide `should_expand`:
+   - `required_pass`: all `answer` in `required_results` are `"yes"`
+   - `optional_pass`: count of `answer="yes"` in `optional_results` / total ≥ 0.6
    - `should_expand = not (required_pass and optional_pass)`
-4. If JSON parsing fails, default `should_expand = true` (conservative strategy)
-5. If `should_expand = false`: Skip Step 2, assign variable and write to temporary directory, record `prompts_expand_skipped = true`:
+3. **Conservative fallback**: if `EVAL_STATUS` is not `ok` (the evaluation call itself failed) or `extract_json.py` exits non-zero, default `should_expand = true`. Unlike Steps 2.0 / 2.3, a failed evaluation does **not** abort the Worker — `auto` falls back to expanding.
+4. If `should_expand = true`: execute Step 2.
+5. If `should_expand = false`: skip Step 2, set `EXPANDED_PROMPT` to the original prompt, record `prompts_expand_skipped = true`:
 
    ```bash
    EXPANDED_PROMPT="$USER_PROMPT"
    echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
    ```
 
-6. If `should_expand = true`: Execute Step 2
+**`force` mode**:
 
-**Evaluation Call** (using `sn-image-base`'s `sn-text-optimize` tool):
+- Skip the evaluation, always execute Step 2 (expansion is mandatory).
+- `prompts_expand_skipped` is **not** recorded — the field appears in the Return JSON only when Step 2 is skipped (see Return Contract rules).
 
-```bash
-EVAL_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
-  --system-prompt-path "$SKILL_DIR/references/evaluation-standard.md" \
-  --user-prompt "$USER_PROMPT" \
-  --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
+**`disable` mode**:
 
-# A failed runner envelope (status != ok) carries no .result.
-EVAL_STATUS=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.status')
+- Skip both the evaluation and Step 2; use `user_prompt` directly as `expanded_prompt`:
 
-# evaluation JSON (required_results / optional_results) lives inside .result
-EVAL=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.result' \
-  | python "$SN_IMAGE_BASE/scripts/extract_json.py")
-```
+  ```bash
+  EXPANDED_PROMPT="$USER_PROMPT"
+  echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
+  ```
 
-If `EVAL_STATUS` is not `ok` (the evaluation call itself failed), or either `extract_json.py` exits non-zero, treat the evaluation as unparseable and default `should_expand = true` (conservative strategy, per auto-mode rule 4). Unlike Steps 2.0 / 2.3, a failed evaluation does **not** abort the Worker — `auto` mode falls back to expanding.
+- Record `prompts_expand_skipped = true`.
 
 #### Step 2 — Content Analysis + Layout & Style Selection + Prompt Expansion
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -135,6 +135,8 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 
 **Naming**: `$SKILL_DIR` for own files; `$SN_<SKILL_NAME>` (e.g. `$SN_IMAGE_BASE`) for cross-skill references.
 
+**JSON parsing**: every `sn_agent_runner.py ... -o json` call prints a JSON *envelope* on stdout (`{"status", "result", "model", ...}`; diagnostics go to stderr). The LLM's own JSON (evaluation / analysis steps) lives inside the `result` string and may carry stray prose or ` ```json ` fences. Before any `jq`, pipe the runner output through `$SN_IMAGE_BASE/scripts/extract_json.py` (reads stdin, prints the recovered JSON, exits non-zero when none is found); for steps that parse the inner LLM/VLM JSON, pipe `.result` through it as well. A non-zero exit means the response is unusable → return the Error Flow JSON.
+
 #### Step 0 — Initialization
 
 1. Generate `task_id` (timestamp, format `YYYYMMDD_HHMMSS`) and create the uniform temporary directory `/tmp/openclaw/sn-infographic/<task_id>/` as `TEMP_DIR`. `TEMP_DIR` must exist before any subsequent step writes to it:
@@ -169,8 +171,8 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 
 **`auto` mode**:
 
-1. Call sn-text-optimize for evaluation
-2. Parse JSON (response schema defined by `$SKILL_DIR/references/evaluation-standard.md`); extract `required_results` and `optional_results`
+1. Call sn-text-optimize for evaluation (see **Evaluation Call** below)
+2. Parse the inner evaluation JSON via `extract_json.py` (response schema defined by `$SKILL_DIR/references/evaluation-standard.md`); extract `required_results` and `optional_results`
 3. Determine logic:
    - `required_pass`: All `answer` in `required_results` are `"yes"`
    - `optional_pass`: The number of `answer="yes"` in `optional_results` / total ≥ 0.6
@@ -188,27 +190,34 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 **Evaluation Call** (using `sn-image-base`'s `sn-text-optimize` tool):
 
 ```bash
-python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
+EVAL_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
   --system-prompt-path "$SKILL_DIR/references/evaluation-standard.md" \
   --user-prompt "$USER_PROMPT" \
-  --output-format json
+  --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
+
+# evaluation JSON (required_results / optional_results) lives inside .result
+EVAL=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.result' \
+  | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
+
+If either `extract_json.py` exits non-zero, treat the evaluation as unparseable and default `should_expand = true` (conservative strategy, per auto-mode rule 4).
 
 #### Step 2 — Content Analysis + Layout & Style Selection + Prompt Expansion
 
 **2.0 Content Analysis** (using `sn-image-base`'s `sn-text-optimize` tool):
 
 ```bash
-ANALYSIS=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
+ANALYSIS_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
   --system-prompt-path "$SKILL_DIR/references/analysis-framework.md" \
   --user-prompt "$USER_PROMPT" \
-  --output-format json)
+  --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
 
-Save analysis result stdout to `analysis.json` in temporary directory `$TEMP_DIR/analysis.json`:
+Extract the inner analysis JSON from `.result` and save it to `$TEMP_DIR/analysis.json` (the **inner** JSON, not the envelope, so Step 2.1 can `jq` `data_type` / `tone` / `audience` directly). If `extract_json.py` exits non-zero, return the Error Flow JSON.
 
 ```bash
-echo "$ANALYSIS" > "$TEMP_DIR/analysis.json"
+printf '%s' "$ANALYSIS_ENVELOPE" | jq -r '.result' \
+  | python "$SN_IMAGE_BASE/scripts/extract_json.py" > "$TEMP_DIR/analysis.json"
 ```
 
 Schema: `$SKILL_DIR/references/analysis-framework.md` (defines `data_type`, `tone`, `audience`, and the other fields consumed by Step 2.1 / 2.2).
@@ -285,15 +294,16 @@ STYLE=$(jq -r '.style' "$TEMP_DIR/layout-style.json")
 Use the content of `structured-content.md` as user-prompt (passed via `--user-prompt-path` to avoid argv-length and quoting issues), read system prompt from temporary file and call sn-text-optimize:
 
 ```bash
-python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
+EXPAND_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optimize \
   --system-prompt-path "$TEMP_DIR/expand-system-prompt.md" \
   --user-prompt-path "$TEMP_DIR/structured-content.md" \
-  --output-format json
+  --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
 
-Parse JSON stdout, extract `result` field as `expanded_prompt`, and write to temporary directory:
+Extract the `result` field as `expanded_prompt` and write to temporary directory. Here `.result` is the expanded prompt **text** (not JSON), so only the envelope is parsed via `extract_json.py`:
 
 ```bash
+EXPANDED_PROMPT=$(printf '%s' "$EXPAND_ENVELOPE" | jq -r '.result')
 echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
 ```
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -135,7 +135,7 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 
 **Naming**: `$SKILL_DIR` for own files; `$SN_<SKILL_NAME>` (e.g. `$SN_IMAGE_BASE`) for cross-skill references.
 
-**JSON parsing**: every `sn_agent_runner.py ... -o json` call prints a JSON *envelope* on stdout (`{"status", "result", "model", ...}`; diagnostics go to stderr). The LLM's own JSON (evaluation / analysis steps) lives inside the `result` string and may carry stray prose or ` ```json ` fences. Before any `jq`, pipe the runner output through `$SN_IMAGE_BASE/scripts/extract_json.py` (reads stdin, prints the recovered JSON, exits non-zero when none is found); for steps that parse the inner LLM/VLM JSON, pipe `.result` through it as well. A non-zero exit means the response is unusable → return the Error Flow JSON.
+**JSON parsing**: every `sn_agent_runner.py ... -o json` call prints a JSON *envelope* on stdout (`{"status", "result", "model", ...}`; diagnostics go to stderr). A failed call sets `status` to a non-`ok` value (e.g. `failed`) and omits `result`, so **always confirm `.status == ok` on the envelope before reading `.result`** — otherwise a missing `.result` surfaces as the literal `null`, which is itself valid JSON and slips past both `jq -r` and `extract_json.py` (no error raised). The LLM's own JSON (evaluation / analysis steps) lives inside the `result` string and may carry stray prose or ` ```json ` fences. Before any `jq`, pipe the runner output through `$SN_IMAGE_BASE/scripts/extract_json.py` (reads stdin, prints the recovered JSON, exits non-zero when none is found); for steps that parse the inner LLM/VLM JSON, pipe `.result` through it as well. A non-`ok` status or a non-zero `extract_json.py` exit means the response is unusable → return the Error Flow JSON.
 
 #### Step 0 — Initialization
 
@@ -195,12 +195,15 @@ EVAL_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-optim
   --user-prompt "$USER_PROMPT" \
   --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 
+# A failed runner envelope (status != ok) carries no .result.
+EVAL_STATUS=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.status')
+
 # evaluation JSON (required_results / optional_results) lives inside .result
 EVAL=$(printf '%s' "$EVAL_ENVELOPE" | jq -r '.result' \
   | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
 
-If either `extract_json.py` exits non-zero, treat the evaluation as unparseable and default `should_expand = true` (conservative strategy, per auto-mode rule 4).
+If `EVAL_STATUS` is not `ok` (the evaluation call itself failed), or either `extract_json.py` exits non-zero, treat the evaluation as unparseable and default `should_expand = true` (conservative strategy, per auto-mode rule 4). Unlike Steps 2.0 / 2.3, a failed evaluation does **not** abort the Worker — `auto` mode falls back to expanding.
 
 #### Step 2 — Content Analysis + Layout & Style Selection + Prompt Expansion
 
@@ -213,9 +216,15 @@ ANALYSIS_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-o
   --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
 
-Extract the inner analysis JSON from `.result` and save it to `$TEMP_DIR/analysis.json` (the **inner** JSON, not the envelope, so Step 2.1 can `jq` `data_type` / `tone` / `audience` directly). If `extract_json.py` exits non-zero, return the Error Flow JSON.
+First reject a failed runner envelope, then extract the inner analysis JSON from `.result` and save it to `$TEMP_DIR/analysis.json` (the **inner** JSON, not the envelope, so Step 2.1 can `jq` `data_type` / `tone` / `audience` directly). If the envelope `.status` is not `ok`, or `extract_json.py` exits non-zero, return the Error Flow JSON (`status=error`) carrying the envelope's `.error` to Main Agent and terminate.
 
 ```bash
+# A failed runner envelope (status != ok) has no .result → return Error Flow.
+if [ "$(printf '%s' "$ANALYSIS_ENVELOPE" | jq -r '.status')" != "ok" ]; then
+  ANALYSIS_ERROR=$(printf '%s' "$ANALYSIS_ENVELOPE" | jq -r '.error')
+  # return Error Flow JSON {"status":"error","error":"$ANALYSIS_ERROR"} to Main Agent and stop
+fi
+
 printf '%s' "$ANALYSIS_ENVELOPE" | jq -r '.result' \
   | python "$SN_IMAGE_BASE/scripts/extract_json.py" > "$TEMP_DIR/analysis.json"
 ```
@@ -300,16 +309,22 @@ EXPAND_ENVELOPE=$(python "$SN_IMAGE_BASE/scripts/sn_agent_runner.py" sn-text-opt
   --output-format json | python "$SN_IMAGE_BASE/scripts/extract_json.py")
 ```
 
-Extract the `result` field as `expanded_prompt` and write to temporary directory. Here `.result` is the expanded prompt **text** (not JSON), so only the envelope is parsed via `extract_json.py`:
+Extract the `result` field as `expanded_prompt` and write to temporary directory. Here `.result` is the expanded prompt **text** (not JSON), so only the envelope is parsed via `extract_json.py`. Confirm `.status == ok` first: a failed envelope has no `.result`, so `jq -r '.result'` would yield the literal string `null` and write `"null"` as the image prompt:
 
 ```bash
+# A failed runner envelope (status != ok) has no .result → return Error Flow.
+if [ "$(printf '%s' "$EXPAND_ENVELOPE" | jq -r '.status')" != "ok" ]; then
+  EXPAND_ERROR=$(printf '%s' "$EXPAND_ENVELOPE" | jq -r '.error')
+  # return Error Flow JSON {"status":"error","error":"$EXPAND_ERROR"} to Main Agent and stop
+fi
+
 EXPANDED_PROMPT=$(printf '%s' "$EXPAND_ENVELOPE" | jq -r '.result')
 echo "$EXPANDED_PROMPT" > "$TEMP_DIR/expanded-prompt.txt"
 ```
 
 `expanded-prompt.txt`: single UTF-8 string, passed verbatim to `sn-image-generate --prompt` in Step 3.
 
-If parsing fails or truncation is suspected (the returned content is incomplete), Worker Agent must immediately return the Error Flow JSON (`status=error` with the real error message) to Main Agent and terminate — Worker is not allowed to message the user directly (see Responsibility Boundaries).
+If the envelope status is not `ok`, parsing fails, or truncation is suspected (the returned content is incomplete), Worker Agent must immediately return the Error Flow JSON (`status=error` with the real error message — use the envelope's `.error` when present) to Main Agent and terminate — Worker is not allowed to message the user directly (see Responsibility Boundaries).
 
 #### Step 3 — Image Generation Loop
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -74,7 +74,7 @@ This skill uses a two-tier agent architecture:
 | Role | Responsibility |
 |------|----------------|
 | **Main Agent** | Receive user request, normalize parameters, send preflight, start Worker, collect results, send text and images to user |
-| **Worker Agent** | Execute orchestration loop (expand → multiple rounds of generation + review → sort), return structured JSON |
+| **Worker Agent** | Execute the generation pipeline (expand → multiple rounds of generation + review → sort), return structured JSON |
 
 **Responsibility Boundaries**:
 
@@ -150,13 +150,15 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 2. Initialize an empty `rounds` list
 3. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SKILL_DIR/references/runtime-parameters.md`
 
-#### Step 1 — Expansion Gate (mandatory; decides whether Step 2 runs)
+#### Step 1 — Decide whether to rewrite the image prompt (always runs)
 
-This step **always runs**. It produces the gate decision `should_expand` and, whenever Step 2 is skipped, sets `EXPANDED_PROMPT` and records `prompts_expand_skipped = true`.
+This step decides whether to **rewrite/expand the user's image-generation `prompt` text** before Step 3 generates the image, and produces the boolean `should_expand`. When Step 2 is skipped it also sets `EXPANDED_PROMPT` and records `prompts_expand_skipped = true`.
 
-`PROMPTS_EXPAND_MODE` here is the **already-resolved input** handed over by the Main Agent — Step 1 *acts on* it, it does **not** re-parse the user request. Resolving the mode value (Main Agent parameter extraction) and running this gate are two different jobs: completing the former does **not** complete Step 1. **Do not skip this step**; in `auto` mode the evaluation call below is mandatory — never infer `should_expand` from the prompt's apparent quality.
+**Scope (do not over-read the step name).** "Expand" here means *rewriting the text prompt for image generation*, nothing more. This is **not** task decomposition, plan generation, or a plan-review gate, and Step 1 starts no agents of its own — it is a single `sn-text-optimize` call made by the Worker itself. Do not map it onto any `subagent-driven-development` / `delegate_task`-style workflow, and write no plan files. (The Worker is the only sub-agent this skill uses, started once by the Main Agent; the Worker spawns none of its own — see Responsibility Boundaries.)
 
-Only **Step 2 (expansion)** is ever skipped, and only when this gate decides so. The branch depends on `PROMPTS_EXPAND_MODE`:
+`PROMPTS_EXPAND_MODE` is the **already-resolved input** handed over by the Main Agent — Step 1 *acts on* it, it does **not** re-parse the user request. Resolving the mode value (Main Agent parameter extraction) and running this decision are two different jobs: completing the former does **not** complete Step 1. **Do not skip this step**; in `auto` mode the evaluation call below is mandatory — never infer `should_expand` from the prompt's apparent quality.
+
+Only **Step 2 (prompt expansion)** is ever skipped, and only when this step decides so. The branch depends on `PROMPTS_EXPAND_MODE`:
 
 **`auto` mode** (default):
 
@@ -424,7 +426,7 @@ After Worker Agent completes, its last message must be and only be the following
   "early_terminated": true,
   "timing": {
     "total_elapsed_seconds": 35.12,
-    "prompt_detection": { "elapsed_seconds": 2.11, "model": "sensenova-6.7-flash-lite" },
+    "prompt_evaluation": { "elapsed_seconds": 2.11, "model": "sensenova-6.7-flash-lite" },
     "content_analysis": { "elapsed_seconds": 3.22, "model": "sensenova-6.7-flash-lite" },
     "prompt_expand": { "elapsed_seconds": 8.45, "model": "sensenova-6.7-flash-lite" }
   },
@@ -473,7 +475,7 @@ After Worker Agent completes, its last message must be and only be the following
 - When `max_rounds=1`, the single round's `result` defaults to `"PASS"` (image delivered without VLM check).
 - Top-level `timing`:
   - `total_elapsed_seconds`: Worker wall time from Step 0 to JSON return.
-  - `prompt_detection`: `{elapsed_seconds, model}` from Step 1 evaluation. Present only when `prompts_expand_mode=auto`.
+  - `prompt_evaluation`: `{elapsed_seconds, model}` from Step 1 evaluation. Present only when `prompts_expand_mode=auto`.
   - `content_analysis`: `{elapsed_seconds, model}` from Step 2.0. Omitted when `prompts_expand_skipped=true`.
   - `prompt_expand`: `{elapsed_seconds, model}` from Step 2.3. Omitted when `prompts_expand_skipped=true`.
 - `rounds[].timing.image_generation.model`: hardcoded `"sn_image_model"` (sn-image-generate returns no model field).
@@ -519,7 +521,7 @@ Images (sent in rank order)
 | `#k round=<n> result=… violations=…` | One line per entry in `rounds[]`, in rank order (`k = 1..len(rounds)`); `<n>` is `rounds[i].round`. |
 | `[early terminated]` | Append **only** to the round that actually triggered early termination (i.e. the `result=PASS` round that cut the loop). Omit on all other lines. If `early_terminated` is absent from the Return JSON, the tag never appears. |
 | `Total <total>s` | `timing.total_elapsed_seconds`. Always present. |
-| `Prompt evaluation <t>s` | `timing.prompt_detection.elapsed_seconds`. **Omit this `\| Prompt evaluation …` segment entirely** when `prompt_detection` is absent from the Return JSON. |
+| `Prompt evaluation <t>s` | `timing.prompt_evaluation.elapsed_seconds`. **Omit this `\| Prompt evaluation …` segment entirely** when `prompt_evaluation` is absent from the Return JSON. |
 | `Content analysis <t>s` | `timing.content_analysis.elapsed_seconds`. Omit the segment entirely when absent. |
 | `Prompt expansion <t>s` | `timing.prompt_expand.elapsed_seconds`. Omit the segment entirely when absent. |
 | `Image generation <t>s×<n> rounds` | `<t>` = sum of `rounds[].timing.image_generation.elapsed_seconds`; `<n>` = `len(rounds)`. |

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -237,14 +237,16 @@ Schema: `$SKILL_DIR/references/analysis-framework.md` (defines `data_type`, `ton
 
 **2.1 Layout & Style Selection**
 
+This is a **name-level, weighted-random pick** from the candidate tables in `$SKILL_DIR/references/layout-style-selection.md`; it operates purely on layout/style **names**. **Do NOT open any file under `references/layouts/` or `references/styles/` here**, and do not "compare options" to choose a best fit — the pick is random, not reasoned over file contents. The one selected layout file and one selected style file are read exactly once, later, in Step 2.3.
+
 1. Read analysis result from temporary directory `$TEMP_DIR/analysis.json`;
 
   ```bash
   ANALYSIS=$(cat "$TEMP_DIR/analysis.json")
   ```
 
-2. Based on `data_type`, `tone`, `audience`, select `layout` and `style` based on the rules in `$SKILL_DIR/references/layout-style-selection.md`;
-3. Validate the selection by checking the definition files exist; fall back to `hub-spoke` + `corporate-memphis` if missing:
+2. From `data_type` / `tone` / `audience`, run the candidate lookup + weighted-random sampling defined in `$SKILL_DIR/references/layout-style-selection.md` to obtain one `LAYOUT` name and one `STYLE` name (names only — no file reads);
+3. Validate the selection by checking the definition files exist (existence only via `[ -f ]`, still no reading); fall back to `hub-spoke` + `corporate-memphis` if missing:
 
   ```bash
   [ -f "$SKILL_DIR/references/layouts/${LAYOUT}.md" ] || LAYOUT=hub-spoke
@@ -547,3 +549,5 @@ Images (sent in rank order)
 - `references/structured-content-template.md` - Structured content template
 - `references/layouts/<layout>.md` - Layout definitions (87 layouts)
 - `references/styles/<style>.md` - Style definitions (66 styles)
+
+Read **only the selected** layout/style file (in Step 2.3); never bulk-read these two directories to choose — selection is name-level and random (Step 2.1).

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -49,8 +49,10 @@ Features:
 | `prompts_expand_mode` | string | `auto` | `auto`: evaluate `user_prompt` quality first; enter Step 2 expansion only when it falls short |
 |                       |        |          | `force`: skip evaluation, always execute Step 2 expansion |
 |                       |        |          | `disable`: skip Step 2, use `user_prompt` directly as `expanded_prompt` |
-| `aspect_ratio` | string | *inferred* (`16:9`) | Aspect ratio for image generation. Inferred from `user_prompt` (see `references/runtime-parameters.md`). |
-| `image_size` | string | *inferred* (`2k`) | Image size for image generation. Inferred from `user_prompt` (see `references/runtime-parameters.md`). |
+| `aspect_ratio` | string | *inferred* (`16:9`) | Set by **Main Agent** when the user states an explicit supported ratio (e.g. `16:9` / `9:16`, optionally via `宽高比` / `画面比例` / `aspect ratio`); otherwise left unset and the **Worker** infers it in Step 0 from `user_prompt` (orientation / scene cues) per `references/runtime-parameters.md`. |
+| `image_size` | string | *inferred* (`2k`) | **Derived, not user-set.** The Worker infers it in Step 0 from `user_prompt` (`1k` only when the user explicitly asks for a cheaper / faster / smaller draft, else `2k`) per `references/runtime-parameters.md`; there is no inline-KV or keyword directive for it. |
+
+> **Who extracts what:** Main Agent parameter extraction resolves `max_rounds`, `output_mode`, `prompts_expand_mode`, and `aspect_ratio` (only when the user gives an explicit ratio). `image_size`, and `aspect_ratio` without an explicit value, are inferred by the Worker in Step 0.
 
 ## API Configuration
 
@@ -88,7 +90,7 @@ This skill uses a two-tier agent architecture:
 ### Main Agent Workflow
 
 1. **Parameter extraction** from the user request, in three passes:
-   1. **Inline KV directives** — parse tokens of the form `key=value` where `key` ∈ {`max_rounds`, `output_mode`, `prompts_expand_mode`}; strip recognized tokens from the user message, and the remainder becomes `user_prompt`. Example: `"生成一张信息图 max_rounds=3 output_mode=verbose"` → `user_prompt="生成一张信息图"`, `max_rounds=3`, `output_mode=verbose`.
+   1. **Inline KV directives** — parse tokens of the form `key=value` where `key` ∈ {`max_rounds`, `output_mode`, `prompts_expand_mode`, `aspect_ratio`}; strip recognized tokens from the user message, and the remainder becomes `user_prompt`. Example: `"生成一张信息图 max_rounds=3 output_mode=verbose"` → `user_prompt="生成一张信息图"`, `max_rounds=3`, `output_mode=verbose`.
    2. **Keyword recognition** (case-insensitive, applied to the stripped text) — fill any parameter not yet set by inline KV using the table below:
 
       | Parameter | Trigger keywords | Resolved value |
@@ -98,8 +100,9 @@ This skill uses a two-tier agent architecture:
       | `max_rounds` | `N 轮`, `N rounds`, `重试 N 次` (parse `N`) | `N`, clamped to `[1, 8]` |
       | `prompts_expand_mode` | `强制扩写`, `force expand`, `force expansion` | `force` |
       |                       | `不扩写`, `跳过扩写`, `disable expansion`, `no expand` | `disable` |
+      | `aspect_ratio` | an explicit supported ratio (`16:9` `9:16` `4:3` `3:4` `1:1` `2:3` `3:2` `4:5` `5:4` `21:9` `9:21`), with or without a `宽高比` / `画面比例` / `比例` / `aspect ratio` lead-in | that ratio (validated against the supported set in `runtime-parameters.md`; unsupported value → leave unset for Worker inference) |
 
-   3. **Defaults** — any parameter still unset falls back to `max_rounds=1`, `output_mode=friendly`, `prompts_expand_mode=auto`.
+   3. **Defaults** — any parameter still unset falls back to `max_rounds=1`, `output_mode=friendly`, `prompts_expand_mode=auto`. `aspect_ratio` has **no** Main-Agent default: when no explicit ratio is detected it is left unset for the Worker to infer in Step 0.
 
    Precedence: **inline KV > keyword recognition > default**. Values from inline KV are validated against the Input Specification (out-of-range `max_rounds` clamped to `[1, 8]`; unrecognized enum values fall back to default and Main Agent should log the mismatch).
 2. Send uniform preflight message: `"Using sn-infographic skill to generate infographic, please wait..."`
@@ -112,7 +115,7 @@ This skill uses a two-tier agent architecture:
 
 ### Worker Agent Workflow
 
-Worker Agent receives `user_prompt`, `max_rounds`, `prompts_expand_mode`, and the working directory of this skill (`SKILL_DIR`). (`output_mode` stays on the Main Agent side — Worker has no branch that depends on it.)
+Worker Agent receives `user_prompt`, `max_rounds`, `prompts_expand_mode`, an optional `aspect_ratio` (set only when the user gave an explicit ratio), and the working directory of this skill (`SKILL_DIR`). (`output_mode` stays on the Main Agent side — Worker has no branch that depends on it.)
 
 #### Worker Environment
 
@@ -128,7 +131,7 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
 | `TASK_ID` | Step 0 (`date +%Y%m%d_%H%M%S`) | uniqueness token |
 | `TEMP_DIR` | Step 0 (`/tmp/openclaw/sn-infographic/${TASK_ID}`) | scratch dir for all intermediate artifacts |
 | `IMAGE_SIZE` | Step 0 (inferred from `USER_PROMPT`, default `2k`) | `sn-image-generate --image-size` |
-| `ASPECT_RATIO` | Step 0 (inferred from `USER_PROMPT`, default `16:9`) | `sn-image-generate --aspect-ratio` |
+| `ASPECT_RATIO` | Main Agent input when the user stated an explicit ratio, else Step 0 inference from `USER_PROMPT` (default `16:9`) | `sn-image-generate --aspect-ratio` |
 | `EXPANDED_PROMPT` | Step 1 (copy of `USER_PROMPT` when Step 2 is skipped) or Step 2.3 (expanded result) | `sn-image-generate --prompt` |
 | `LAYOUT`, `STYLE` | Step 2.1 selection result (with fallback to `hub-spoke` / `corporate-memphis`) | Step 2.3 system-prompt assembly |
 | `ROUND` | Step 3 loop counter (`for ROUND in $(seq 1 "$MAX_ROUNDS")`) | per-round file naming (`round_${ROUND}.png`) |
@@ -148,7 +151,7 @@ Variables referenced as `$NAME` in the bash snippets below. Worker must bind eac
    ```
 
 2. Initialize an empty `rounds` list
-3. Infer `aspect_ratio` (default `16:9`) and `image_size` (default `2k`) from `user_prompt` based on the rules in `$SKILL_DIR/references/runtime-parameters.md`
+3. Resolve `aspect_ratio`: if the Main Agent passed an explicit `aspect_ratio`, use it as-is (assign to `ASPECT_RATIO`); otherwise infer it (default `16:9`) from `user_prompt`. Always infer `image_size` (default `2k`) from `user_prompt`. Both follow the rules in `$SKILL_DIR/references/runtime-parameters.md`.
 
 #### Step 1 — Decide whether to rewrite the image prompt (always runs)
 

--- a/skills/sn-infographic/SKILL.md
+++ b/skills/sn-infographic/SKILL.md
@@ -86,8 +86,8 @@ This skill uses a two-tier agent architecture:
 2. Send uniform preflight message: `"Using sn-infographic skill to generate infographic, please wait..."`
 3. Start Worker Agent (Sub-Agent), passing in complete parameters and working directory
 4. When Worker Agent returns `status=ok` and `need_main_agent_send=true`:
-   - **max_rounds = 1**: Send a one-sentence description of the image content, then send the rank=1 single image
-   - **max_rounds > 1, friendly mode**: Generate a one-sentence natural language description based on `result` and `violations`, send the evaluation text, then send the rank=1 single image
+   - **max_rounds = 1**: Generate a one-sentence description of the image content from `expanded_prompt` in the returned JSON (always present for `status=ok`, see Return Contract), then send the rank=1 single image
+   - **max_rounds > 1, friendly mode**: Generate a one-sentence natural language description based on the rank=1 round's `result` and `violations`, send the evaluation text, then send the rank=1 single image
    - **max_rounds > 1, verbose mode**: Send complete text summary message, then send all images in rank order to the user
 5. If Worker Agent returns `status=error`, report the real `error` field content to the user
 
@@ -124,7 +124,8 @@ Worker Agent receives `user_prompt`, `max_rounds`, `output_mode`, `prompts_expan
 
 **`force` mode**:
 
-- Directly execute Step 2
+- Skip evaluation entirely, always execute Step 2 (expansion is mandatory)
+- `prompts_expand_skipped` is **not** recorded — the field appears in the Return JSON only when Step 2 is skipped (see Return Contract rules)
 
 **`auto` mode**:
 
@@ -334,7 +335,7 @@ After Worker Agent completes, its last message must be and only be the following
   "status": "ok",
   "need_main_agent_send": true,
   "output_mode": "friendly|verbose",
-  "expanded_prompt": "<always contains when output_mode=verbose; value is original user_prompt when prompts_expand_skipped=true, otherwise is expanded result>",
+  "expanded_prompt": "<always present in status=ok responses regardless of output_mode; value is original user_prompt when prompts_expand_skipped=true, otherwise the expanded result from Step 2.3>",
   "prompts_expand_skipped": true,
   "early_terminated": true,
   "timing": {
@@ -372,16 +373,20 @@ After Worker Agent completes, its last message must be and only be the following
 **Rules:**
 
 - `status=ok` must contain `need_main_agent_send: true`
-- `expanded_prompt` must contain when `output_mode=verbose`; value is original `user_prompt` when `prompts_expand_skipped=true`
-- `prompts_expand_skipped` must contain when expand is not executed (value is `true`), covering two cases: `prompts_expand_mode=disable` and `prompts_expand_mode=auto` and evaluation passes and skip expand
+- `expanded_prompt` is always present in `status=ok` responses (regardless of `output_mode`); value is the original `user_prompt` when `prompts_expand_skipped=true`, otherwise the expanded prompt produced in Step 2.3
+- `prompts_expand_skipped` is present (value `true`) **only** when Step 2 is skipped — covers two cases:
+  - `prompts_expand_mode=disable`
+  - `prompts_expand_mode=auto` and Step 1 evaluation passes
+  The field is **omitted** (semantically `false`) in all other cases, i.e. `prompts_expand_mode=force` or `auto` with evaluation failing
 - `early_terminated` must contain when early termination (value is `true`), omitted when normal execution completes
 - `violations` is an array of strings, from review results
 - `reasoning` is an empty string when `max_rounds=1`
 - Top-level `timing` contains:
   - `total_elapsed_seconds`: Worker Agent's wall time from Step 0 to returning JSON, calculated by Worker Agent itself
-  - `prompt_detection`: Step 1 evaluation call, containing `elapsed_seconds` and `model` (read from sn-text-optimize JSON return); omitted when `prompts_expand_mode=disable`
-  - `content_analysis`: Step 2.0 content analysis call, containing `elapsed_seconds` and `model` (read from sn-text-optimize JSON return); omitted when expand is skipped
-  - `prompt_expand`: Step 2.3 prompt expansion call, containing `elapsed_seconds` and `model` (read from sn-text-optimize JSON return); omitted when expand is skipped
+  - `prompt_detection`: Step 1 evaluation call; **present only when `prompts_expand_mode=auto`** (omitted under `disable` and `force`, neither of which invokes the evaluation)
+  - `content_analysis`: Step 2.0 content analysis call; **omitted when Step 2 is skipped** (i.e. `prompts_expand_skipped=true`)
+  - `prompt_expand`: Step 2.3 prompt expansion call; **omitted when Step 2 is skipped** (i.e. `prompts_expand_skipped=true`)
+  - Each of the three sub-objects contains `elapsed_seconds` and `model` (read from the sn-text-optimize JSON return)
 - `rounds[].timing.image_generation.model` is fixed to the hardcoded placeholder `"sn_image_model"`
 - `rounds[].timing.vlm_review` is omitted when `max_rounds=1`
 

--- a/skills/sn-infographic/references/layout-style-selection.md
+++ b/skills/sn-infographic/references/layout-style-selection.md
@@ -2,6 +2,8 @@
 
 Resolved by the Worker Agent's own reasoning — no additional LLM call required.
 
+**Operate on names only.** This whole procedure manipulates layout/style **names** (e.g. `hub-spoke`, `corporate-memphis`). **Never open the definition files under `references/layouts/*.md` or `references/styles/*.md` to make the choice** — the pick is a weighted *random* draw, not a quality comparison, so their contents are irrelevant here. Only the two finally-selected files are read, once, in SKILL.md Step 2.3.
+
 ## Step 1 — Layout Candidates (by data_type)
 
 Analyze the information structure of `user_prompt`, determine the `data_type`, and map to layout candidates.
@@ -62,17 +64,28 @@ Each context has a primary (match_score=1.0) and alternatives (match_score=0.7).
 
 ## Step 3 — Random Sampling
 
-Layout and style are sampled independently using the same process:
-
-1. Build a weighted candidate pool: repeat the primary item **10 times**, each alternative item **9 times**, then randomly pick **3 items** from all available options outside the current data_type / context and repeat each **1 time**, then merge into the candidate pool
-2. Shuffle the pool with bash `shuf` and take the first item as the result:
+Layout and style are sampled independently using the same process, **on names only**. The "all available options" universe is just the **filenames** under `references/layouts/` and `references/styles/` — enumerate them with `ls` (names, not contents):
 
 ```bash
-LAYOUT=$(printf '%s\n' "${LAYOUT_POOL[@]}" | shuf | head -1)
-STYLE=$(printf '%s\n' "${STYLE_POOL[@]}" | shuf | head -1)
+mapfile -t ALL_LAYOUTS < <(ls "$SKILL_DIR/references/layouts/" | sed 's/\.md$//')
+mapfile -t ALL_STYLES  < <(ls "$SKILL_DIR/references/styles/"  | sed 's/\.md$//')
 ```
 
-The weighting gives primary and alternatives roughly equal win probability (~10:9), with non-matching items having a combined win probability of ~10%.
+For each of layout and style, build the weighted pool from the matched row of the table above — the **primary** name ×10, each **alternative** name ×9, plus **3 random names** drawn from the full `ls` list (outside the current data_type / context) ×1 — then shuffle and take the first. Example for layout (style is identical with `ALL_STYLES`):
+
+```bash
+PRIMARY_LAYOUT="hub-spoke"                       # match_score=1.0 row for this data_type
+ALT_LAYOUTS=(jigsaw multi-focal venn-diagram)    # match_score=0.7 alternatives
+
+LAYOUT_POOL=()
+for _ in $(seq 10); do LAYOUT_POOL+=("$PRIMARY_LAYOUT"); done
+for a in "${ALT_LAYOUTS[@]}"; do for _ in $(seq 9); do LAYOUT_POOL+=("$a"); done; done
+for r in $(printf '%s\n' "${ALL_LAYOUTS[@]}" | shuf | head -3); do LAYOUT_POOL+=("$r"); done
+
+LAYOUT=$(printf '%s\n' "${LAYOUT_POOL[@]}" | shuf | head -1)
+```
+
+The weighting gives primary and alternatives roughly equal win probability (~10:9), with the random non-matching items a combined ~10%.
 
 ## Fallback
 

--- a/skills/sn-infographic/references/runtime-parameters.md
+++ b/skills/sn-infographic/references/runtime-parameters.md
@@ -18,14 +18,14 @@ Map into:
 
 ## Image Size
 
-**Default: `2k`** — always used unless the user explicitly says otherwise. Never ask the user about this.
+If the Main Agent already resolved an explicit `image_size` (the user stated a supported size upstream), use it directly. Otherwise infer it — the inference currently has a **single option, `2k`**. Never ask the user about it.
 
 Rules:
 
-- **Never ask the user about `image_size`.** Default silently to `2k`.
-- If the user explicitly asks for lower cost, faster draft, quick concept, or small output, use `--image-size 1k`.
-- If the user explicitly asks for higher detail, print-quality, poster-quality, fine text, or large output, use `--image-size 2k`.
-- Otherwise use `--image-size 2k` (default).
+- Supported explicit values: `2k`, `4k`. Take the user's value only when stated explicitly (`image_size=4k`, or a bare `2k` / `4k` token, optionally after an `image_size` / `分辨率` / `清晰度` lead-in).
+- Vague quality words (`高清`, `超清`, `print-quality`, "faster draft", …) do **not** count as an explicit size — ignore them.
+- With no explicit size, the inference resolves to `2k`.
+- `4k` is passed straight to the image model; a model that can't render it (e.g. sensenova) returns an error, which the skill surfaces as-is.
 
 ## Aspect Ratio
 
@@ -69,7 +69,7 @@ Otherwise, use the first matching rule:
 ## Notes
 
 - The skill should pass `expanded_prompt` (from `prompts-expand`) as `--prompt`, not the raw user request.
-- `image_size` defaults to `2k` — the Worker Agent must NOT ask the user about it.
+- `image_size`: the Main Agent takes an explicit `2k` / `4k`; otherwise the Worker infers it in Step 0 — currently a single option, `2k`. Never ask the user about it.
 - `aspect_ratio` is inferred from the **original `user_prompt`** (before expansion), not from `expanded_prompt`.
 - Prefer inference over interruption when there is one clearly reasonable choice.
 - Ask the user only when multiple aspect ratios are genuinely plausible and the choice would materially change composition or layout.

--- a/skills/sn-infographic/references/runtime-parameters.md
+++ b/skills/sn-infographic/references/runtime-parameters.md
@@ -43,7 +43,9 @@ Supported values:
 - `21:9`
 - `9:21`
 
-Use the first matching rule:
+If the Main Agent already resolved an explicit `aspect_ratio` (the user stated a supported ratio upstream), and is a valid value (in the supported values above), use it directly and skip the rules below — this is rule 1 applied at the Main Agent boundary.
+
+Otherwise, use the first matching rule:
 
 1. If the user explicitly gives a supported ratio, use it directly.
 2. If the user confirms a ratio preference in a follow-up turn, use that confirmed value.


### PR DESCRIPTION
## Summary

Bundled fixes and refinements grouped by affected skill; within each group, ordered by impact.

### `sn-image-base`

- **`parse_response` no longer crashes on malformed 2xx responses (Fixes #91)**: the three backends now append only validated `str` image fields, so a safety-filtered / text-only / partial response degrades to the structured `EmptyResponse` failure dict instead of an unhandled `base64.b64decode(None)` → `TypeError`.
- **Unified failure schema across CLI and all three backends**: every failure is now `{"status":"failed","error_type":<class|tag>,"error":<details>,"elapsed_seconds":<float>}`, so callers no longer branch on which layer produced the error.
- **Runner imports on Windows**: the POSIX-only `import resource` is now lazy (inside `check_file_descriptor_limit`'s `try/except ImportError`), so the runner no longer dies with `ModuleNotFoundError` at import time on Windows. No POSIX change.
- **`--image-size` errors are structured and case-insensitive**: invalid values return JSON (`status=failed`) instead of argparse's stderr `SystemExit(2)`; `2K` / `2k` both accepted.
- **`4k` image-size is now selectable (`2k` stays the recommended default)**: `4k` passes the input gate and is forwarded to the upstream model — `openai-image` derives the 4k-scale `WxH`, `nano-banana` forwards the `4k` preset token, and the upstream returns the real error if it can't render it. The `sensenova` backend has no 4k pixel bucket, so it rejects `4k` locally with a `status=failed` JSON. Docs recommend `2k` and mark `4k` optional / model-dependent.

### `sn-image-base` + `sn-infographic` (shared runner I/O)

- **Runner stdout is pure JSON, and JSON parsing is failure-safe**: diagnostics moved from stdout to stderr (stdout is now a single JSON line). New `scripts/extract_json.py` recovers a JSON value from noisy text (leading/trailing prose, ```json``` fences, scanning successive brackets). sn-infographic Steps 1 / 2.0 / 2.3 now confirm `.status == ok` before reading `.result` — a failed envelope has no `.result`, so it previously flowed through as the literal `null` and became the image prompt; it now returns Error Flow (or defaults `should_expand=true` in Step 1). Step 2.0 persists the **inner** analysis JSON to `analysis.json`.

### `sn-infographic`

- **Worker contract tightened**: Worker never messages the user directly (Step 2.3 truncation + Step 3 VLM no-model/failure paths return Error Flow JSON); Step 3 rounds write distinct `round_${ROUND}.png` (no overwrite); added the Worker Environment binding table; normalized the Return JSON; `violations` is now the VLM's structured object schema; shell-variable naming aligned with sister skills (`$SKILL_DIR` self, `$SN_<SKILL>` cross-skill).
- **`aspect_ratio` and `image_size` resolved at the Main Agent when explicit**: when the user states a supported value — a ratio (`16:9`) or a size (`2k` / `4k`), via inline KV or keyword — the Main Agent extracts it and passes it down; otherwise it stays unset and the Worker infers it in Step 0. `image_size` inference currently has a single option, `2k`; the obsolete `1k` rule was dropped (`1k` is no longer in the sn-image-base image-size gate).
- **Step 1 reframed as a prompt-rewrite decision, not orchestration**: clarified that "expand" means rewriting the image-generation prompt text (a single `sn-text-optimize` call), not task decomposition / plan generation / a plan-review gate; dropped orchestration-loaded vocabulary that made agents pattern-match into delegating; trimmed redundant status-guard prose in Steps 2.0 / 2.3.
- **Layout & style selection operates on names only**: the weighted-random pick manipulates layout/style **names** (enumerated via `ls`), and agents no longer bulk-read the `references/layouts/*` or `references/styles/*` definition files to choose — only the two finally-selected files are read, once, in Step 2.3.

## Test plan

- [x] `py_compile` + `ruff check` on all touched files
- [x] `--image-size`: `2k` / `2K` → success; `1k` → JSON `status=failed` (exit 1); HTTP error → correct `error_type`
- [x] `--image-size 4k`: `openai-image` → 4k-scale `WxH` forwarded; `sensenova` → `status=failed` JSON (no network call); `8k` → input-gate `status=failed`
- [x] #91: 5 malformed 2xx payloads → `EmptyResponse` failure dict; valid payload still decodes
- [x] Windows: `import sn_agent_runner` succeeds with `resource` unavailable (was `ModuleNotFoundError`)
- [x] `extract_json.py`: prose / fence / trailing junk / brace-in-string / multi-bracket all recovered; garbage and empty → exit 1
- [x] failed envelope → Error Flow with `.error`; `status=ok` envelope → proceeds
- [x] sister-skill smoke (`sn-image-resume` / `sn-image-imitate`) — no runner regression
- [x] sn-infographic dry-run — all Worker Environment variables bound

## Notes

- argparse missing-param exits (e.g. `--prompt` omitted) still go through argparse's stderr + exit-code-2 path; unifying those would require overriding `parser.error()` and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
