### PR TITLE
fix: gracefully skip PPTX export when headless browser is unavailable

### DIFF
--- a/skills/sn-ppt-creative/SKILL.md
+++ b/skills/sn-ppt-creative/SKILL.md
@@ -210,8 +210,8 @@ python3 $SKILL_DIR/scripts/build_pptx.py --deck-dir <deck_dir>
 - 页序按 `outline.json` 的 `page_no` 排；缺失 `outline.json` 时按 `page_001..page_NNN` 走。
 - 缺失的 PNG 会插入空白页并在 stderr 记录一行，**不中止**；这样跟 Stage 4 的"失败跳过"语义一致。
 - 脚本失败（依赖缺失 / 写盘失败）：echo 失败原因，**不中止整个 skill**，仍进入 Stage 6 收尾；PNG 已在磁盘上。
-
-依赖：`python-pptx`（与 `sn-ppt-standard` 共用的打包思路；若运行环境未装，由 `sn-ppt-doctor` 的 env check 提示安装）。
+  如果 python-pptx 缺失导致失败：🚫 **不要尝试 pip install python-pptx**
+  或任何替代方案。PNG 页面已经是最终交付物，直接进入 Stage 6。
 
 ## Stage 6 — closing
 

--- a/skills/sn-ppt-doctor/ppt_doctor/check_environment.py
+++ b/skills/sn-ppt-doctor/ppt_doctor/check_environment.py
@@ -387,6 +387,45 @@ def check_python_deps() -> CheckResult:
     )
 
 
+def check_playwright_chromium(base: Path | None = None) -> CheckResult:
+    """Check if Playwright Chromium is available (optional — export can skip)."""
+    if base is None:
+        repo_root = Path(__file__).resolve().parents[3]
+        base = repo_root / "skills" / "sn-ppt-standard" / "scripts" / "export_pptx"
+
+    if not (base / "node_modules" / "playwright").exists():
+        return CheckResult(
+            name="PLAYWRIGHT_CHROMIUM",
+            severity="soft",
+            passed=True,
+            detail="Playwright not installed — PPTX export will be skipped. HTML pages still produced.",
+        )
+
+    try:
+        result = subprocess.run(
+            ["npx", "playwright", "install", "--dry-run", "chromium"],
+            capture_output=True, text=True, timeout=30,
+            cwd=str(base),
+        )
+        installed = "is already installed" in result.stdout
+    except Exception:
+        installed = False
+
+    if installed:
+        return CheckResult(
+            name="PLAYWRIGHT_CHROMIUM",
+            severity="soft",
+            passed=True,
+            detail="Playwright Chromium is installed — PPTX export available",
+        )
+    return CheckResult(
+        name="PLAYWRIGHT_CHROMIUM",
+        severity="soft",
+        passed=True,
+        detail="Chromium not available — PPTX export will be skipped. HTML pages still produced.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # 4. Aggregator
 # ---------------------------------------------------------------------------
@@ -403,6 +442,7 @@ def run_all_checks() -> list[CheckResult]:
         check_ppt_deck_root_writable(),
         check_optional_env_vars(),
         check_export_pptx_node_modules(),
+        check_playwright_chromium(),
         check_python_deps(),
     ]
 

--- a/skills/sn-ppt-standard/SKILL.md
+++ b/skills/sn-ppt-standard/SKILL.md
@@ -31,6 +31,7 @@ Any missing → stop and tell user to enter via `/skill sn-ppt-entry`.
 3. **Do NOT construct LLM prompts yourself.** `run_stage.py` is the only place that builds payloads.
 4. **Do NOT add `timing` / logging / retry layers.** The skill is intentionally thin.
 5. **Do NOT go silent between execs.** Echo a one-line Chinese progress message after each exec before issuing the next.
+6. **Do NOT use python-pptx or any alternative PPTX builder** when export is skipped or fails. The HTML pages are complete as-is — there is no fallback renderer. An absent PPTX is an acceptable ending state.
 
 ## Pipeline
 
@@ -122,7 +123,9 @@ Run `python $SKILL_DIR/lib/model_client.py health` to verify env before running 
 
 `scripts/export_pptx/html_to_pptx.mjs` is invoked with `--force` — skips built-in motif / real-photo gates (this skill doesn't use the motif protocol). PPTX still produces even if some slots are missing images.
 
-If the converter crashes, `run_stage.py export` returns `status: "failed"`. That's the deck's ending state; PPTX is simply absent.
+If the headless browser (Playwright/Chromium) is unavailable, the export returns `status: "skipped"` with reason `"headless_browser_unavailable"`. The PPTX file is absent — this is an expected degraded ending state. The HTML pages are the final deliverable.
+
+🚫 **DO NOT fall back to python-pptx, libreoffice, or any other converter.** DO NOT attempt to install Chromium system dependencies manually. Simply report the skip and finish.
 
 ## Does NOT
 

--- a/skills/sn-ppt-standard/scripts/export_pptx/html_to_pptx.mjs
+++ b/skills/sn-ppt-standard/scripts/export_pptx/html_to_pptx.mjs
@@ -21,7 +21,11 @@ function ensureDependencies() {
 
   if (!existsSync(pptxgenMarker) || !existsSync(playwrightMarker)) {
     console.error('[setup] 首次运行，正在安装 npm 依赖...');
-    execSync('npm install --omit=dev', { cwd: __dirname, stdio: 'inherit' });
+    try {
+      execSync('npm install --omit=dev', { cwd: __dirname, stdio: 'inherit' });
+    } catch (e) {
+      throw new Error(`npm install failed: ${e.message}. Headless browser environment unavailable.`);
+    }
   }
 
   // 检查 chromium 是否已安装（playwright 在 ~/.cache/ms-playwright/ 下）
@@ -40,11 +44,16 @@ function ensureDependencies() {
     });
   } catch {
     console.error('[setup] 正在安装 Playwright Chromium（仅首次）...');
-    execSync('npx playwright install chromium', { cwd: __dirname, stdio: 'inherit' });
+    try {
+      execSync('npx playwright install chromium', { cwd: __dirname, stdio: 'inherit' });
+    } catch (e) {
+      throw new Error(`Chromium installation failed: ${e.message}. Cannot install headless browser in this environment.`);
+    }
   }
 }
 
-ensureDependencies();
+// ensureDependencies() 移到 main() 中调用，避免模块加载时崩溃。
+// missing browser → 优雅跳过，不抛异常。
 
 // 依赖就绪后再 import 业务模块
 const { ensureDeckPreconditions } = await import('./lib/cli_guards.mjs');
@@ -79,6 +88,23 @@ function parseArgs(args) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+
+  // 确保依赖安装（npm + playwright chromium）。
+  // missing browser → 输出 JSON skip 状态，优雅退出（不崩溃）。
+  try {
+    ensureDependencies();
+  } catch (e) {
+    const result = {
+      status: "skipped",
+      reason: "headless_browser_unavailable",
+      detail: `Playwright/Chromium cannot be installed in this environment: ${e.message}. PPTX export skipped — HTML pages are the final deliverable.`,
+      converted: 0,
+      pages: 0,
+      skipped: true,
+    };
+    console.log(JSON.stringify(result));
+    return;
+  }
 
   // 先下载远程图片并规范化 deck 结构
   if (args.deckDir && !args.batch) {

--- a/skills/sn-ppt-standard/scripts/export_pptx/lib/dom_extractor.mjs
+++ b/skills/sn-ppt-standard/scripts/export_pptx/lib/dom_extractor.mjs
@@ -827,7 +827,20 @@ function _attachSvgPngsToIR(_ir, _svgPngs) {
  * @returns {Promise<Array<{path:string, ir:Object|null, error?:string}>>}
  */
 export async function extractPages(htmlPaths) {
-  const browser = await chromium.launch({ headless: true });
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch (e) {
+    // Browser unavailable — return null IR for every page.
+    // pptx_builder handles null IR gracefully (blank slide + continue).
+    console.error(`[dom_extractor] Chromium unavailable: ${e.message}`);
+    return htmlPaths.map(path => ({
+      path,
+      ir: null,
+      error: `Chromium unavailable: ${e.message}`,
+    }));
+  }
+
   const results = [];
 
   try {

--- a/skills/sn-ppt-standard/scripts/run_stage.py
+++ b/skills/sn-ppt-standard/scripts/run_stage.py
@@ -1042,6 +1042,14 @@ def cmd_export(deck: Path) -> int:
         last = [l for l in stdout.splitlines() if l.strip().startswith("{")]
         if last:
             info = json.loads(last[-1])
+            # Graceful skip: headless browser unavailable → not a failure
+            if info.get("status") == "skipped":
+                return {
+                    "status": "skipped",
+                    "stage": "export",
+                    "reason": info.get("reason"),
+                    "detail": info.get("detail"),
+                }
             converted = info.get("converted")
             pages = info.get("pages")
             failed = info.get("failed")


### PR DESCRIPTION
When Playwright/Chromium cannot be installed (e.g., container without system libraries), the export stage now returns status: "skipped" instead of crashing. SKILL.md files explicitly forbid python-pptx or any other fallback — HTML pages are the final deliverable when export is skipped.

- html_to_pptx.mjs: move ensureDependencies() into main() with try/catch
- dom_extractor.mjs: catch chromium.launch() failure, return null IR
- run_stage.py cmd_export: handle "skipped" status from subprocess
- sn-ppt-standard SKILL.md: add hard rule #6 forbidding python-pptx fallback
- sn-ppt-creative SKILL.md: forbid pip install python-pptx on build failure
- sn-ppt-doctor: add PLAYWRIGHT_CHROMIUM soft check