### PR TITLE
docs: add FAQ for generation troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,37 @@ A few `sn-infographic` outputs (more in [`docs/sn-infographic-examples.md`](docs
 
 - Depends on: [`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md), [`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)
 
+## FAQ
+
+### PPT generation times out on complex decks. What should I do?
+
+For `sn-ppt-standard`, each slide is generated as a complete HTML page. Content-heavy decks, such as an 11-page deck with complex layouts, charts, and detailed styling, may need more time than the default LLM timeout.
+
+Increase the text and vision timeout values before running the PPT pipeline:
+
+```bash
+export SN_TEXT_TIMEOUT=300
+export SN_VISION_TIMEOUT=300
+```
+
+You can also set the shared fallback timeout:
+
+```bash
+export SN_CHAT_TIMEOUT=300
+```
+
+If both `SN_TEXT_TIMEOUT` and `SN_CHAT_TIMEOUT` are set, `SN_TEXT_TIMEOUT` takes priority for text LLM calls. If both `SN_VISION_TIMEOUT` and `SN_CHAT_TIMEOUT` are set, `SN_VISION_TIMEOUT` takes priority for vision calls.
+
+### Some Chinese text in an infographic is unclear. What should I do?
+
+For `sn-infographic`, run more than one generation round so the skill can use VLM review to check the generated image and prefer outputs with fewer visual issues:
+
+```text
+Create a Chinese infographic about <topic> max_rounds=3 output_mode=verbose
+```
+
+When `max_rounds=1`, VLM review is skipped. Setting `max_rounds` to `2` or higher gives the workflow a chance to catch problems such as garbled Chinese text, duplicated/overlapping characters, and unclear text-image layout.
+
 ## Contributing
 
 Feel free to use the skills here as templates for your own OpenClaw skills. The qualities that make a skill good:

--- a/README_CN.md
+++ b/README_CN.md
@@ -174,6 +174,37 @@ Hermes 把目录换成 `~/.hermes/skills/` 即可。
 
 - 依赖技能：[`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md)、[`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)
 
+## 常见问题
+
+### PPT 生成在复杂页面上超时怎么办？
+
+`sn-ppt-standard` 会把每一页幻灯片生成为一份完整的 HTML 页面。对于内容较重的 PPT，例如 11 页且包含复杂布局、图表和细致样式的页面，默认的 LLM 超时时间可能不够。
+
+运行 PPT 流程前，可以调大文本与视觉模型的超时时间：
+
+```bash
+export SN_TEXT_TIMEOUT=300
+export SN_VISION_TIMEOUT=300
+```
+
+也可以设置共享兜底超时时间：
+
+```bash
+export SN_CHAT_TIMEOUT=300
+```
+
+如果同时设置了 `SN_TEXT_TIMEOUT` 和 `SN_CHAT_TIMEOUT`，文本 LLM 调用会优先使用 `SN_TEXT_TIMEOUT`。如果同时设置了 `SN_VISION_TIMEOUT` 和 `SN_CHAT_TIMEOUT`，视觉模型调用会优先使用 `SN_VISION_TIMEOUT`。
+
+### 中文信息图中部分文字不够清晰怎么办？
+
+使用 `sn-infographic` 时，可以增加生成轮数，让技能启用 VLM review 检查生成结果，并优先选择视觉问题更少的输出：
+
+```text
+生成一张关于<主题>的中文信息图 max_rounds=3 output_mode=verbose
+```
+
+当 `max_rounds=1` 时，VLM review 会被跳过。将 `max_rounds` 设置为 `2` 或更高，可以让流程有机会发现中文乱码、重复/重叠文字、文图排版不清晰等问题。
+
 ## 贡献
 
 欢迎以本仓库的技能为模板创建你自己的 OpenClaw 技能。一个好技能的核心要素：


### PR DESCRIPTION
## Summary
- Add README FAQ entries for PPT timeout mitigation via timeout env vars
- Add README FAQ guidance for using sn-infographic VLM review on unclear Chinese text
- Keep English and Chinese README content in sync

## Tests
- Not run; documentation-only change