### PR TITLE
feat: add sn-da-other-files skill for Word/PDF/PPT document analysis

### DIFF
--- a/skills/sn-da-other-files/SKILL.md
+++ b/skills/sn-da-other-files/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: sn-da-other-files
+description: "Word / PDF / PPT 文档解析与数据分析引擎。覆盖三类文件格式的全量提取、表格数值化、图表理解与跨文档汇总分析。**遇到以下任一情况就主动使用本 skill**：①用户上传或指定了 .docx / .doc / .pdf / .pptx / .ppt 文件并要求分析、提取或统计其中内容；②用户出现触发词：Word分析 / PDF解析 / PPT提取 / 文档分析 / 报告解析 / 幻灯片分析 / 发票提取 / 合同分析 / 文档统计 / 错别字 / 语病 / 字号检查 / 简历分析 / 多文档对比；③任务涉及从文档中提取表格、数值、图表、格式（颜色/高亮/字号）、组织架构、时间线等结构化信息。仅不用于：Excel/CSV 数据分析（使用 sn-da-excel-workflow）、纯图片分析（使用 sn-da-image-caption）。"
+---
+
+# Document Analysis Skill — Word / PDF / PPT
+
+End-to-end workflow for Word, PDF, and PPT document parsing. Each format has
+specific parsing pitfalls — follow the format-specific sub-skill exactly.
+
+---
+
+## Workflow
+
+### Step 0 — Identify file type and input scope
+
+```python
+import os
+
+input_path = "/mnt/data/..."  # from user
+
+# Detect single file vs directory (multi-file scenario)
+if os.path.isdir(input_path):
+    all_files = [
+        os.path.join(input_path, f)
+        for f in os.listdir(input_path)
+        if f.lower().endswith(('.docx', '.doc', '.pdf', '.pptx', '.ppt'))
+    ]
+    print(f"Found {len(all_files)} documents: {all_files}")
+else:
+    all_files = [input_path]
+
+# Route by extension
+ext = os.path.splitext(all_files[0])[-1].lower()
+print(f"File type: {ext}")
+```
+
+> **Critical rule**: When `input_path` is a directory OR the user says "这些文件" / "所有文档",
+> process **every file** and aggregate. Never stop at the first file.
+
+---
+
+### Step 1 — Load sub-skill by format
+
+| Extension | Sub-skill to load |
+|-----------|------------------|
+| `.docx` / `.doc` | `capability/word-analysis/SKILL.md` |
+| `.pdf` | `capability/pdf-analysis/SKILL.md` |
+| `.pptx` / `.ppt` | `capability/ppt-analysis/SKILL.md` |
+
+```
+read_file(path="<skills_root>/sn-da-other-files/capability/<format>-analysis/SKILL.md")
+```
+
+Load **only the sub-skill you need** — do not load all three at once.
+
+---
+
+### Step 2 — Parse and extract
+
+Follow the sub-skill's extraction pattern. For all formats:
+
+- **Full scan**: iterate all pages/slides/paragraphs — never stop early
+- **Table extraction**: get every table, not just the first one
+- **Image/chart detection**: if a page/slide yields no text, treat it as image-based and call `caption.py`
+
+---
+
+### Step 3 — Answer with verification
+
+After extracting data, verify before answering:
+
+```python
+# For count/statistics questions: spot-check 3-5 items
+sample = result_list[:3]
+print(f"Sample check: {sample}")
+print(f"Total count: {len(result_list)}")
+
+# For numeric calculations: print intermediate values
+print(f"Max={max_val}, Min={min_val}, Range={max_val - min_val}")
+
+# For unit-sensitive answers: always include the unit
+print(f"Answer: {value} {unit}")  # e.g., "475 千港元" not just "475"
+```
+
+---
+
+## Universal Rules
+
+### MUST DO
+- **Always iterate all pages/slides/paragraphs** — `for page in doc`, `for slide in prs.slides`, `for para in doc.paragraphs`
+- **When input is a directory**: collect and process all matching files, then aggregate results
+- **For scanned PDFs**: detect empty text → call `caption.py` for OCR
+- **For image-only slides**: text extraction returns empty → render slide as PNG → call `caption.py`
+- **For calculations**: show intermediate values; confirm unit matches the question
+
+### NEVER DO
+- Do NOT use `pytesseract` or `easyocr` as primary OCR — they are not installed; use `caption.py`
+- Do NOT use PIL pixel analysis to infer chart values — use vision model caption instead
+- Do NOT stop at the first file, first page, or first table
+- Do NOT guess content from filenames — always parse the actual file
+- Do NOT output percentage when the question asks for absolute value (and vice versa)
+
+---
+
+## Caption Script (for image/chart content in any document)
+
+When a page, slide, or embedded image needs vision understanding, load the
+`sn-da-image-caption` skill first, then use its `scripts/caption.py`:
+
+```
+read_file(path="<skills_root>/sn-da-image-caption/SKILL.md")
+```
+
+```python
+import subprocess, json
+
+CAPTION = "/path/to/skills/sn-da-image-caption/scripts/caption.py"
+
+def caption_image(image_path, prompt=None):
+    cmd = ["python3", CAPTION, image_path, "--json"]
+    if prompt:
+        cmd += ["--prompt", prompt]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(f"caption failed: {result.stderr[:200]}")
+    return json.loads(result.stdout)["description"]
+
+# Example prompts by content type:
+# Table:  "提取表格所有内容，Markdown 表格格式，保持行列结构，数值不四舍五入。"
+# Chart:  "提取图表标题、坐标轴标签、每个数据点的数值。Markdown 表格输出。"
+# Diagram: "描述所有节点和连接关系。"
+```
+
+---
+
+## Available sub-skills
+
+```
+sn-da-other-files/capability/word-analysis/SKILL.md   — .docx/.doc
+sn-da-other-files/capability/pdf-analysis/SKILL.md    — .pdf
+sn-da-other-files/capability/ppt-analysis/SKILL.md    — .pptx/.ppt
+```

--- a/skills/sn-da-other-files/capability/pdf-analysis/SKILL.md
+++ b/skills/sn-da-other-files/capability/pdf-analysis/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: pdf-analysis
+description: "PDF 文档解析。自动区分文字型 PDF 与扫描型 PDF，覆盖：文本/表格提取、多页全量扫描、嵌入图表 caption、单位感知数值计算。"
+---
+
+# PDF Analysis
+
+## Step 0 — Detect PDF type (text vs scanned)
+
+**Critical first step**: determine whether the PDF has extractable text or is a scanned image.
+Never skip this — using the wrong parser wastes time and produces empty results.
+
+```python
+import fitz  # PyMuPDF
+
+def detect_pdf_type(pdf_path, sample_pages=3):
+    """
+    Returns 'text' if PDF has extractable text, 'scanned' if image-based.
+    Checks first N pages (or all if fewer).
+    """
+    doc = fitz.open(pdf_path)
+    total_chars = 0
+    pages_checked = min(sample_pages, len(doc))
+
+    for i in range(pages_checked):
+        page = doc[i]
+        text = page.get_text("text")
+        total_chars += len(text.strip())
+
+    doc.close()
+    avg_chars = total_chars / max(pages_checked, 1)
+    pdf_type = 'text' if avg_chars > 50 else 'scanned'
+    print(f"PDF type: {pdf_type} (avg {avg_chars:.0f} chars/page, checked {pages_checked} pages)")
+    return pdf_type
+```
+
+---
+
+## Core Method 1: Text PDF — Full Text Extraction (ALL pages)
+
+```python
+import fitz
+
+def extract_text_pdf(pdf_path):
+    """Extract text from all pages of a text-based PDF."""
+    doc = fitz.open(pdf_path)
+    total_pages = len(doc)
+    print(f"Total pages: {total_pages}")
+
+    all_text = []
+    for i, page in enumerate(doc):
+        text = page.get_text("text").strip()
+        if text:
+            all_text.append(f"=== Page {i+1} ===\n{text}")
+        else:
+            print(f"  Page {i+1}: no text (may be image — will caption later)")
+
+    doc.close()
+    return '\n\n'.join(all_text)
+
+# ⚠️ MUST iterate ALL pages — never stop at page 1
+full_text = extract_text_pdf(pdf_path)
+print(f"Total text length: {len(full_text)} chars")
+```
+
+---
+
+## Core Method 2: Text PDF — Table Extraction
+
+For PDFs with tables, `pdfplumber` gives better table structure than `fitz`:
+
+```python
+import pdfplumber
+import pandas as pd
+
+def extract_tables_pdf(pdf_path):
+    """Extract all tables from all pages as DataFrames."""
+    all_tables = []
+    with pdfplumber.open(pdf_path) as pdf:
+        print(f"Total pages: {len(pdf.pages)}")
+        for i, page in enumerate(pdf.pages):
+            tables = page.extract_tables()
+            for j, tbl in enumerate(tables):
+                if not tbl:
+                    continue
+                # First row as header
+                df = pd.DataFrame(tbl[1:], columns=tbl[0])
+                # Clean: strip whitespace, replace None
+                df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
+                df = df.dropna(how='all').reset_index(drop=True)
+                all_tables.append({'page': i+1, 'table_idx': j, 'df': df})
+                print(f"  Page {i+1}, Table {j}: {df.shape[0]}r × {df.shape[1]}c")
+                print(df.head(3))
+    return all_tables
+
+# Verify table alignment after extraction:
+# Print column headers and first 3 rows to confirm row/col mapping is correct
+```
+
+---
+
+## Core Method 3: Scanned PDF — OCR via Caption
+
+For scanned PDFs (image-based pages), render each page as PNG and caption:
+
+```python
+import fitz
+import subprocess, json, os
+
+CAPTION = "/path/to/skills/sn-da-image-caption/scripts/caption.py"
+
+def extract_scanned_pdf(pdf_path, prompt=None, dpi=150):
+    """Render each page as image, then caption for text extraction."""
+    doc = fitz.open(pdf_path)
+    total_pages = len(doc)
+    print(f"Scanned PDF: {total_pages} pages, captioning each...")
+
+    all_text = []
+    for i, page in enumerate(doc):
+        # Render page to PNG
+        mat = fitz.Matrix(dpi/72, dpi/72)
+        pix = page.get_pixmap(matrix=mat)
+        img_path = f"/tmp/pdf_page_{i+1}.png"
+        pix.save(img_path)
+
+        # Caption the page image
+        cmd = ["python3", CAPTION, img_path, "--json"]
+        if prompt:
+            cmd += ["--prompt", prompt]
+        else:
+            cmd += ["--prompt", "提取页面中所有文字和表格内容，保持原始结构，Markdown格式输出。"]
+
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+        if r.returncode == 0:
+            desc = json.loads(r.stdout).get("description", "")
+            all_text.append(f"=== Page {i+1} ===\n{desc}")
+            print(f"  Page {i+1}: {len(desc)} chars extracted")
+        else:
+            print(f"  Page {i+1}: caption failed — {r.stderr[:100]}")
+
+    doc.close()
+    return '\n\n'.join(all_text)
+
+# Usage for scanned invoice PDFs, bank statements, org charts, etc.
+text = extract_scanned_pdf(pdf_path)
+```
+
+---
+
+## Core Method 4: Hybrid PDF (mixed text + image pages)
+
+```python
+def extract_hybrid_pdf(pdf_path, text_prompt=None, image_prompt=None):
+    """Handle PDFs where some pages have text, others are scanned."""
+    doc_fitz = fitz.open(pdf_path)
+    all_text = []
+
+    for i, page in enumerate(doc_fitz):
+        raw_text = page.get_text("text").strip()
+
+        if len(raw_text) > 50:
+            # Text page — use directly
+            all_text.append(f"=== Page {i+1} (text) ===\n{raw_text}")
+        else:
+            # Image page — render and caption
+            mat = fitz.Matrix(150/72, 150/72)
+            pix = page.get_pixmap(matrix=mat)
+            img_path = f"/tmp/hybrid_page_{i+1}.png"
+            pix.save(img_path)
+
+            cmd = ["python3", CAPTION, img_path, "--json"]
+            prompt = image_prompt or "提取页面中所有文字和表格内容，Markdown格式输出。"
+            cmd += ["--prompt", prompt]
+
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+            if r.returncode == 0:
+                desc = json.loads(r.stdout).get("description", "")
+                all_text.append(f"=== Page {i+1} (image→caption) ===\n{desc}")
+            else:
+                all_text.append(f"=== Page {i+1} (caption failed) ===")
+
+    doc_fitz.close()
+    return '\n\n'.join(all_text)
+```
+
+---
+
+## Core Method 5: Extract Embedded Images / Charts from PDF
+
+```python
+import fitz
+
+def extract_pdf_images(pdf_path, min_width=100, min_height=100):
+    """Extract all embedded images from a PDF (charts, diagrams, photos)."""
+    doc = fitz.open(pdf_path)
+    image_paths = []
+
+    for page_num, page in enumerate(doc):
+        for img_idx, img in enumerate(page.get_images(full=True)):
+            xref = img[0]
+            base = doc.extract_image(xref)
+            img_bytes = base["image"]
+            ext = base["ext"]
+
+            img_path = f"/tmp/pdf_img_p{page_num+1}_{img_idx}.{ext}"
+            with open(img_path, 'wb') as f:
+                f.write(img_bytes)
+
+            # Only keep images above size threshold (skip icons/logos)
+            from PIL import Image
+            with Image.open(img_path) as im:
+                w, h = im.size
+            if w >= min_width and h >= min_height:
+                image_paths.append({'page': page_num+1, 'path': img_path, 'size': (w, h)})
+                print(f"  Page {page_num+1}, img {img_idx}: {w}×{h} → {img_path}")
+
+    doc.close()
+    return image_paths
+
+# After extracting, caption each image:
+# for img_info in image_paths:
+#     caption_image(img_info['path'], prompt="提取图表数据，Markdown 表格输出。")
+```
+
+---
+
+## Common Patterns
+
+### Multi-invoice / multi-document PDF (发票汇总)
+
+```python
+# When PDF contains multiple invoices (one per page):
+tables_by_page = extract_tables_pdf(pdf_path)
+invoices = []
+for item in tables_by_page:
+    df = item['df']
+    # Find key fields (flexible column name matching)
+    for col in df.columns:
+        if '金额' in str(col) or 'amount' in str(col).lower():
+            invoices.append({'page': item['page'], 'amount_col': col, 'data': df})
+            break
+print(f"Found {len(invoices)} pages with amount data")
+```
+
+### Numeric extraction with unit awareness
+
+```python
+import re
+
+def extract_number_with_unit(text_snippet):
+    """
+    Extract value and unit from text like '1,760 千港元' or '95,975,196,217.52元'.
+    Returns (numeric_value, unit_string).
+    """
+    # Remove thousands separator
+    text_snippet = text_snippet.replace(',', '')
+    match = re.search(r'([\d\.]+)\s*(千|万|亿|百万)?\s*(元|港元|美元|人民币|%|percent)?', text_snippet)
+    if not match:
+        return None, None
+    value = float(match.group(1))
+    multiplier_map = {'千': 1000, '万': 10000, '亿': 1e8, '百万': 1e6}
+    mult = multiplier_map.get(match.group(2), 1)
+    unit = match.group(3) or ''
+    return value * mult, f"{match.group(2) or ''}{unit}"
+
+# Always verify unit matches what the question asks:
+# "多几多" in HKD → answer in 千港元 if source says 千港元
+```
+
+### Long document keyword search
+
+```python
+def find_in_pdf(pdf_path, keyword, context_chars=200):
+    """Search for keyword across all pages, return context snippets."""
+    text = extract_text_pdf(pdf_path)
+    results = []
+    start = 0
+    while True:
+        idx = text.find(keyword, start)
+        if idx < 0:
+            break
+        snippet = text[max(0, idx-context_chars//2): idx+context_chars]
+        results.append({'pos': idx, 'context': snippet})
+        start = idx + 1
+    print(f"Found '{keyword}' {len(results)} times")
+    return results
+```
+
+---
+
+## Pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Use `pdfplumber` on scanned PDF → empty result | Detect type first (Method 0); use OCR path for scanned |
+| Only read page 1, miss remaining invoices/data | Always `for page in doc` — never index `[0]` only |
+| Table columns misaligned after extraction | Print headers + first 3 rows to verify before computing |
+| Report number as % when question asks absolute value | Read question carefully; `extract_number_with_unit()` preserves context |
+| Chart data embedded as image → pdfplumber returns nothing | Extract images (Method 5), then caption each |
+| Long doc loses cross-page context | Use `find_in_pdf()` for keyword search across full text |
+| `.pdf` contains multiple scanned docs (zip of PDFs) | Check if input is dir or archive; unzip first |

--- a/skills/sn-da-other-files/capability/ppt-analysis/SKILL.md
+++ b/skills/sn-da-other-files/capability/ppt-analysis/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: ppt-analysis
+description: "PPT (.pptx/.ppt) 全量解析。覆盖：所有 slide 文本/表格/图表提取、嵌入图片 caption、纯图片 slide 渲染识别、数据标签提取。"
+---
+
+# PPT Analysis — .pptx / .ppt
+
+## Environment
+
+```python
+from pptx import Presentation
+from pptx.util import Inches
+import os, subprocess, json
+
+# python-pptx is available
+# For .ppt (old binary format): convert via libreoffice
+def load_pptx(path):
+    if path.lower().endswith('.ppt'):
+        import subprocess
+        out_dir = os.path.dirname(path)
+        subprocess.run(
+            ['libreoffice', '--headless', '--convert-to', 'pptx', '--outdir', out_dir, path],
+            check=True, capture_output=True
+        )
+        path = path.rsplit('.', 1)[0] + '.pptx'
+    return Presentation(path), path
+```
+
+---
+
+## Core Method 1: Full Text Extraction (ALL slides)
+
+```python
+def extract_all_slides_text(pptx_path):
+    """
+    Extract text from every slide: text frames, tables, chart titles.
+    For slides with no extractable text, flag them for image captioning.
+    """
+    prs, _ = load_pptx(pptx_path)
+    slides_data = []
+
+    for slide_num, slide in enumerate(prs.slides, start=1):
+        slide_texts = []
+        has_text = False
+
+        for shape in slide.shapes:
+            # Text frame (most common)
+            if shape.has_text_frame:
+                for para in shape.text_frame.paragraphs:
+                    text = para.text.strip()
+                    if text:
+                        slide_texts.append(text)
+                        has_text = True
+
+            # Table
+            if shape.has_table:
+                tbl = shape.table
+                for row in tbl.rows:
+                    row_text = '\t'.join(cell.text.strip() for cell in row.cells)
+                    if row_text.strip():
+                        slide_texts.append(row_text)
+                        has_text = True
+
+            # Chart title
+            if shape.shape_type == 3:  # MSO_SHAPE_TYPE.CHART
+                try:
+                    if shape.chart.has_title:
+                        title = shape.chart.chart_title.text_frame.text
+                        slide_texts.append(f"[Chart: {title}]")
+                        has_text = True
+                except Exception:
+                    pass
+
+        slides_data.append({
+            'slide': slide_num,
+            'text': '\n'.join(slide_texts),
+            'has_text': has_text,
+            'needs_caption': not has_text  # flag image-only slides
+        })
+
+    print(f"Total slides: {len(slides_data)}")
+    image_only = sum(1 for s in slides_data if s['needs_caption'])
+    print(f"Slides with text: {len(slides_data) - image_only}, image-only: {image_only}")
+    return slides_data
+```
+
+---
+
+## Core Method 2: Table Extraction (Structured)
+
+```python
+import pandas as pd
+
+def extract_pptx_tables(pptx_path):
+    """Extract all tables from all slides as DataFrames."""
+    prs, _ = load_pptx(pptx_path)
+    all_tables = []
+
+    for slide_num, slide in enumerate(prs.slides, start=1):
+        for shape in slide.shapes:
+            if not shape.has_table:
+                continue
+            tbl = shape.table
+            rows = []
+            for row in tbl.rows:
+                rows.append([cell.text.strip() for cell in row.cells])
+
+            if not rows:
+                continue
+
+            # Use first row as header
+            try:
+                df = pd.DataFrame(rows[1:], columns=rows[0])
+            except Exception:
+                df = pd.DataFrame(rows)
+
+            all_tables.append({'slide': slide_num, 'df': df})
+            print(f"  Slide {slide_num}: table {df.shape[0]}r × {df.shape[1]}c")
+            print(df.head(3).to_string())
+
+    return all_tables
+```
+
+---
+
+## Core Method 3: Chart Data Extraction
+
+`python-pptx` can read Chart data when it's stored as embedded Excel data.
+If that fails, fall back to captioning the slide image.
+
+```python
+def extract_chart_data(pptx_path):
+    """
+    Extract data series from Chart shapes.
+    Returns list of {slide, chart_title, series_name, categories, values}.
+    """
+    prs, _ = load_pptx(pptx_path)
+    charts = []
+
+    for slide_num, slide in enumerate(prs.slides, start=1):
+        for shape in slide.shapes:
+            if shape.shape_type != 3:  # not a chart
+                continue
+            try:
+                chart = shape.chart
+                title = chart.chart_title.text_frame.text if chart.has_title else f"Chart_S{slide_num}"
+
+                for plot in chart.plots:
+                    for series in plot.series:
+                        try:
+                            categories = [str(pt.label) for pt in series.data_labels] if hasattr(series, 'data_labels') else []
+                            values = [pt.value for pt in series.values] if hasattr(series, 'values') else []
+                            # Alternative: use xChart data
+                            if not values:
+                                values = list(series.values)
+                        except Exception as e:
+                            values = []
+                            categories = []
+
+                        charts.append({
+                            'slide': slide_num,
+                            'chart_title': title,
+                            'series': getattr(series, 'name', ''),
+                            'categories': categories,
+                            'values': values
+                        })
+            except Exception as e:
+                print(f"  Slide {slide_num}: chart extraction failed ({e}) — will use caption")
+
+    return charts
+```
+
+---
+
+## Core Method 4: Render Image-Only Slides → Caption
+
+When a slide has no extractable text (pure image/screenshot slides):
+
+```python
+import fitz  # PyMuPDF can also render PPTX via LibreOffice conversion
+
+CAPTION = "/path/to/skills/sn-da-image-caption/scripts/caption.py"
+
+def caption_image_slides(pptx_path, slides_data, prompt=None):
+    """
+    For slides flagged as 'needs_caption', render to PNG and caption.
+    Uses LibreOffice to convert PPTX to PDF first, then renders pages.
+    """
+    image_slides = [s for s in slides_data if s['needs_caption']]
+    if not image_slides:
+        print("No image-only slides to caption.")
+        return slides_data
+
+    # Convert PPTX → PDF (preserves slide visuals)
+    out_dir = "/tmp"
+    r = subprocess.run(
+        ['libreoffice', '--headless', '--convert-to', 'pdf', '--outdir', out_dir, pptx_path],
+        capture_output=True, text=True
+    )
+    pdf_name = os.path.basename(pptx_path).rsplit('.', 1)[0] + '.pdf'
+    pdf_path = os.path.join(out_dir, pdf_name)
+
+    if not os.path.exists(pdf_path):
+        print(f"LibreOffice conversion failed: {r.stderr[:200]}")
+        return slides_data
+
+    # Render each image-only slide
+    doc = fitz.open(pdf_path)
+    for s in image_slides:
+        page_idx = s['slide'] - 1  # 0-indexed
+        if page_idx >= len(doc):
+            continue
+        page = doc[page_idx]
+        mat = fitz.Matrix(150/72, 150/72)
+        pix = page.get_pixmap(matrix=mat)
+        img_path = f"/tmp/slide_{s['slide']}.png"
+        pix.save(img_path)
+
+        # Caption the slide image
+        cmd = ["python3", CAPTION, img_path, "--json"]
+        p = prompt or "提取幻灯片中所有文字、数值和表格内容，保持结构，Markdown格式输出。"
+        cmd += ["--prompt", p]
+        cr = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+        if cr.returncode == 0:
+            desc = json.loads(cr.stdout).get("description", "")
+            s['text'] = desc
+            s['needs_caption'] = False
+            print(f"  Slide {s['slide']}: captioned ({len(desc)} chars)")
+        else:
+            print(f"  Slide {s['slide']}: caption failed — {cr.stderr[:80]}")
+
+    doc.close()
+    return slides_data
+```
+
+---
+
+## Common Patterns
+
+### Keyword search across all slides
+
+```python
+def find_in_pptx(pptx_path, keyword, slides_data=None):
+    """Find keyword across all slides (after text extraction + captioning)."""
+    if slides_data is None:
+        slides_data = extract_all_slides_text(pptx_path)
+
+    results = []
+    for s in slides_data:
+        if keyword in s.get('text', ''):
+            idx = s['text'].find(keyword)
+            context = s['text'][max(0, idx-100):idx+200]
+            results.append({'slide': s['slide'], 'context': context})
+
+    print(f"'{keyword}' found in {len(results)} slides: {[r['slide'] for r in results]}")
+    return results
+```
+
+### Time-line / process extraction from PPT
+
+```python
+def extract_timeline(pptx_path, date_pattern=r'\d{4}[年/\-]\d{1,2}'):
+    """Extract date-tagged events from slide text."""
+    import re
+    slides_data = extract_all_slides_text(pptx_path)
+    events = []
+    for s in slides_data:
+        for line in s['text'].split('\n'):
+            if re.search(date_pattern, line):
+                events.append({'slide': s['slide'], 'event': line.strip()})
+    return events
+```
+
+### Statistics from PPT tables (e.g., 录用占比)
+
+```python
+def compute_ratio_from_pptx_table(pptx_path, numerator_col, denominator_col):
+    """Example: compute ratio = col_A / col_B for all rows."""
+    tables = extract_pptx_tables(pptx_path)
+    for item in tables:
+        df = item['df']
+        # Try to find columns (flexible matching)
+        num_col = next((c for c in df.columns if numerator_col in c), None)
+        den_col = next((c for c in df.columns if denominator_col in c), None)
+        if num_col and den_col:
+            df[num_col] = pd.to_numeric(df[num_col].str.replace('人', '').str.strip(), errors='coerce')
+            df[den_col] = pd.to_numeric(df[den_col].str.replace('人', '').str.strip(), errors='coerce')
+            df['ratio'] = (df[num_col] / df[den_col] * 100).round(0).astype(str) + '%'
+            print(df[['slide' if 'slide' in df.columns else df.columns[0], num_col, den_col, 'ratio']].to_string())
+```
+
+---
+
+## Full Workflow Example
+
+```python
+pptx_path = "/mnt/data/report.pptx"
+
+# 1. Extract text from all slides
+slides_data = extract_all_slides_text(pptx_path)
+
+# 2. Caption image-only slides
+slides_data = caption_image_slides(pptx_path, slides_data)
+
+# 3. Combine all text for analysis
+all_text = '\n\n'.join(
+    f"[Slide {s['slide']}]\n{s['text']}"
+    for s in slides_data if s.get('text')
+)
+
+# 4. Search or analyze
+results = find_in_pptx(pptx_path, '录用占比', slides_data)
+
+# 5. Extract tables if needed
+tables = extract_pptx_tables(pptx_path)
+```
+
+---
+
+## Pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Skip slides with no text → miss chart data | Flag `needs_caption`, render & caption (Method 4) |
+| `shape.chart.plots[0].series` fails → no data | Catch exception, fall back to captioning the slide |
+| Table columns misread (企业名 vs 岗位名) | Print headers + first 3 rows before computing; verify column meaning |
+| Only read first N slides | Always `for slide in prs.slides` — no index limit |
+| `.ppt` format → `python-pptx` can't open | Convert to `.pptx` via libreoffice first |
+| PPT has overlapping text boxes → garbled order | Sort shapes by top-left position: `sorted(slide.shapes, key=lambda s: (s.top, s.left))` |

--- a/skills/sn-da-other-files/capability/word-analysis/SKILL.md
+++ b/skills/sn-da-other-files/capability/word-analysis/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: word-analysis
+description: "Word (.docx/.doc) 文档全量解析。覆盖：正文/段落文本提取、表格数据提取、高亮/颜色格式读取、多文件汇总对比、嵌入图片转 caption。"
+---
+
+# Word Analysis — .docx / .doc
+
+## Environment
+
+```python
+from docx import Document
+import os
+
+# python-docx is available; for .doc (old format) convert via libreoffice first
+def load_doc(path):
+    """Load .docx directly; convert .doc to .docx first if needed."""
+    if path.lower().endswith('.doc'):
+        import subprocess
+        out_dir = os.path.dirname(path)
+        subprocess.run(
+            ['libreoffice', '--headless', '--convert-to', 'docx', '--outdir', out_dir, path],
+            check=True, capture_output=True
+        )
+        path = path.rsplit('.', 1)[0] + '.docx'
+    return Document(path)
+```
+
+---
+
+## Core Method 1: Full Text Extraction
+
+```python
+def extract_full_text(doc_path):
+    """Extract all text: paragraphs + table cells, in document order."""
+    doc = load_doc(doc_path)
+    lines = []
+
+    # Iterate paragraphs and tables in body order
+    from docx.oxml.ns import qn
+    for block in doc.element.body:
+        tag = block.tag.split('}')[-1]
+        if tag == 'p':
+            # Paragraph
+            from docx.text.paragraph import Paragraph
+            para = Paragraph(block, doc)
+            text = para.text.strip()
+            if text:
+                lines.append(text)
+        elif tag == 'tbl':
+            # Table
+            from docx.table import Table
+            tbl = Table(block, doc)
+            for row in tbl.rows:
+                row_text = '\t'.join(cell.text.strip() for cell in row.cells)
+                if row_text.strip():
+                    lines.append(row_text)
+
+    return '\n'.join(lines)
+
+# Usage
+text = extract_full_text("/mnt/data/doc.docx")
+print(text[:2000])  # preview first 2000 chars
+```
+
+---
+
+## Core Method 2: Table Extraction (Structured)
+
+```python
+import pandas as pd
+
+def extract_all_tables(doc_path):
+    """Extract all tables from a Word document as list of DataFrames."""
+    doc = load_doc(doc_path)
+    tables = []
+
+    for i, tbl in enumerate(doc.tables):
+        rows = []
+        for row in tbl.rows:
+            rows.append([cell.text.strip() for cell in row.cells])
+        if not rows:
+            continue
+        # Use first row as header if it looks like a header
+        df = pd.DataFrame(rows[1:], columns=rows[0]) if rows else pd.DataFrame()
+        tables.append((i, df))
+        print(f"Table {i}: {df.shape[0]} rows × {df.shape[1]} cols")
+        print(df.head(3))
+
+    return tables
+
+# Usage
+tables = extract_all_tables("/mnt/data/doc.docx")
+```
+
+---
+
+## Core Method 3: Format-Aware Extraction (Color / Highlight)
+
+Some questions require reading cell background color or text highlight color
+(e.g., "标黄的行", "红色文字"). Use XML-level access:
+
+```python
+from docx import Document
+from docx.oxml.ns import qn
+from lxml import etree
+
+def get_paragraph_highlight(para):
+    """Return highlight color name of first run, or None."""
+    for run in para.runs:
+        rPr = run._r.find(qn('w:rPr'))
+        if rPr is not None:
+            hl = rPr.find(qn('w:highlight'))
+            if hl is not None:
+                return hl.get(qn('w:val'))  # e.g. 'yellow', 'cyan', 'red'
+    return None
+
+def get_table_cell_shading(cell):
+    """Return background color hex of a table cell, or None."""
+    tcPr = cell._tc.find(qn('w:tcPr'))
+    if tcPr is not None:
+        shd = tcPr.find(qn('w:shd'))
+        if shd is not None:
+            return shd.get(qn('w:fill'))  # hex color, e.g. 'FFFF00'
+    return None
+
+# Example: find all highlighted paragraphs
+def find_highlighted_rows(doc_path, color='yellow'):
+    doc = load_doc(doc_path)
+    highlighted = []
+    for i, para in enumerate(doc.paragraphs):
+        hl = get_paragraph_highlight(para)
+        if hl == color or (color == 'yellow' and hl in ('yellow', 'FFFF00')):
+            highlighted.append((i, para.text))
+    return highlighted
+
+# For table cells with yellow background:
+def find_highlighted_table_cells(doc_path, fill_colors=('FFFF00', 'FFD700')):
+    doc = load_doc(doc_path)
+    results = []
+    for t_idx, tbl in enumerate(doc.tables):
+        for r_idx, row in enumerate(tbl.rows):
+            for c_idx, cell in enumerate(row.cells):
+                color = get_table_cell_shading(cell)
+                if color and color.upper() in fill_colors:
+                    results.append({
+                        'table': t_idx, 'row': r_idx, 'col': c_idx,
+                        'color': color, 'text': cell.text.strip()
+                    })
+    return results
+```
+
+---
+
+## Core Method 4: Multi-File Aggregation
+
+When the user asks about "these files" or the input is a directory:
+
+```python
+def process_all_docs(file_list, extractor_fn):
+    """Apply extractor to all files and aggregate results."""
+    all_results = []
+    for path in file_list:
+        print(f"\n=== Processing: {os.path.basename(path)} ===")
+        try:
+            result = extractor_fn(path)
+            all_results.append({'file': os.path.basename(path), 'data': result})
+        except Exception as e:
+            print(f"  ERROR: {e}")
+    return all_results
+
+# Example: extract text from all .docx in a directory
+doc_files = [f for f in all_files if f.lower().endswith(('.docx', '.doc'))]
+results = process_all_docs(doc_files, extract_full_text)
+```
+
+---
+
+## Core Method 5: Embedded Images → Caption
+
+When a Word doc contains embedded images (charts, screenshots):
+
+```python
+import zipfile, io, subprocess, json
+
+CAPTION = "/path/to/skills/sn-da-image-caption/scripts/caption.py"
+
+def extract_and_caption_images(doc_path, prompt=None):
+    """Extract all images from .docx and caption each one."""
+    # .docx is a ZIP archive; images are in word/media/
+    results = []
+    with zipfile.ZipFile(doc_path, 'r') as z:
+        media_files = [n for n in z.namelist() if n.startswith('word/media/')]
+        for media in media_files:
+            ext = os.path.splitext(media)[-1].lower()
+            if ext not in ('.png', '.jpg', '.jpeg', '.gif', '.bmp', '.wmf', '.emf'):
+                continue
+            # Save to temp
+            tmp_path = f"/tmp/{os.path.basename(media)}"
+            with z.open(media) as src, open(tmp_path, 'wb') as dst:
+                dst.write(src.read())
+            # Caption
+            cmd = ["python3", CAPTION, tmp_path, "--json"]
+            if prompt:
+                cmd += ["--prompt", prompt]
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            if r.returncode == 0:
+                desc = json.loads(r.stdout).get("description", "")
+                results.append({'image': media, 'caption': desc})
+                print(f"  {media}: {desc[:100]}...")
+            else:
+                print(f"  {media}: caption failed — {r.stderr[:80]}")
+    return results
+```
+
+---
+
+## Common Patterns
+
+### Font/size check (字号检查)
+```python
+from docx.shared import Pt
+
+def check_font_sizes(doc_path):
+    doc = load_doc(doc_path)
+    issues = []
+    for i, para in enumerate(doc.paragraphs):
+        for run in para.runs:
+            size = run.font.size
+            size_pt = size.pt if size else None
+            # Also check style-level font
+            if size_pt is None:
+                style_size = run.style.font.size if run.style else None
+                size_pt = style_size.pt if style_size else None
+            issues.append({'para': i, 'text': run.text[:30], 'size_pt': size_pt})
+    return issues
+```
+
+### Spell/grammar check (错别字)
+- Use full-text extraction, then search with string matching or pass to LLM for proofreading
+- Do NOT try to install hunspell or other spell-check tools
+
+### Keyword search (全文定位)
+```python
+def find_keyword(doc_path, keyword):
+    text = extract_full_text(doc_path)
+    idx = text.find(keyword)
+    if idx >= 0:
+        context = text[max(0, idx-100):idx+200]
+        print(f"Found '{keyword}' at pos {idx}:\n{context}")
+    else:
+        print(f"'{keyword}' not found. Try broader search.")
+        # Try case-insensitive or partial match
+        for kw in keyword.split():
+            if kw in text:
+                print(f"  Partial match for '{kw}'")
+```
+
+---
+
+## Pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| Only read `doc.paragraphs`, miss tables | Use the body-order iterator in Method 1 |
+| Single file when input is multi-file | Check `os.path.isdir()`, iterate all |
+| Highlighted cells not detected | Use XML-level `w:shd` / `w:highlight` (Method 3) |
+| `.doc` format fails to open | Convert to `.docx` via libreoffice (Method 0) |
+| Embedded charts look empty | Extract images from ZIP, caption each (Method 5) |
+| Font size is None | Check both run-level and style-level (Method for font check) |


### PR DESCRIPTION
  - Add main skill (SKILL.md) with file type routing and universal rules
  - Add word-analysis subskill: full text/table extraction, highlight color detection via XML, multi-file aggregation, embedded image captioning
  - Add pdf-analysis subskill: text vs scanned PDF detection, full-page iteration, pdfplumber table extraction, scanned page OCR via caption.py
  - Add ppt-analysis subskill: all-slide traversal, chart data extraction, image-only slide rendering + captioning via LibreOffice + fitz