### PR TITLE
refactor(sn-ppt-entry): remove dead table loop

### DIFF
--- a/skills/sn-ppt-entry/scripts/parse_user_docs.py
+++ b/skills/sn-ppt-entry/scripts/parse_user_docs.py
@@ -283,8 +283,6 @@ def main(argv: list[str] | None = None) -> int:
     # Annotate indices for cross-reference from digest / outline
     for di, d in enumerate(documents):
         d["doc_index"] = di
-        for ti, _t in enumerate(d.get("tables") or []):
-            pass  # kept as plain list for simplicity; consumers index by position
         for ii, img in enumerate(d.get("inherited_images") or []):
             img["image_index"] = ii
             img["doc_index"] = di


### PR DESCRIPTION
## Summary
- Remove the no-op table iteration from `parse_user_docs.py`.
- Keep `doc_index` and inherited image index annotations unchanged.

## Validation
- `python3 -m py_compile skills/sn-ppt-entry/scripts/parse_user_docs.py`
- `git diff --check`
- `UV_CACHE_DIR=../.uv-cache uv run --with pypdf --with python-docx python skills/sn-ppt-entry/scripts/parse_user_docs.py --files <sample.md>`

Fixes #128