### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -312,6 +312,20 @@ mkdir -p ~/.hermes/skills
 cp -r skills/* ~/.hermes/skills/
 ```
 
+Autohand Code:
+
+```bash
+# Global install
+mkdir -p ~/.autohand/skills
+cp -r skills/* ~/.autohand/skills/
+
+# Project-level install
+mkdir -p .autohand/skills
+cp -r skills/* .autohand/skills/
+```
+
+Autohand Code also supports `autohand --skill-install` for cataloged skills, with `--project` for workspace-level installs. Until this repository is listed there, use the direct copy or symlink paths above.
+
 > Want skills to track this repo? Use symlinks instead of `cp -r`:
 > ```bash
 > ln -s "$PWD"/skills/* ~/.openclaw/skills/
@@ -324,7 +338,7 @@ Once your agent is up, send it the message below. It will use its own shell tool
 
 > Copy every subdirectory under `SenseNova-Skills/skills/` (in the current directory) into OpenClaw's skill directory (`~/.openclaw/skills/`). When you're done, list the installed skills.
 
-Swap "OpenClaw" and the path for `hermes-agent` / `~/.hermes/skills/` to use this with hermes.
+Swap "OpenClaw" and the path for `hermes-agent` / `~/.hermes/skills/`, Autohand Code global / `~/.autohand/skills/`, or Autohand Code project / `.autohand/skills/` as needed.
 
 > This option works well for picking and choosing — e.g., "only copy `sn-image-*` and `sn-deep-research`."
 

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -312,6 +312,20 @@ mkdir -p ~/.hermes/skills
 cp -r skills/* ~/.hermes/skills/
 ```
 
+Autohand Code：
+
+```bash
+# 全局安装
+mkdir -p ~/.autohand/skills
+cp -r skills/* ~/.autohand/skills/
+
+# 项目级安装
+mkdir -p .autohand/skills
+cp -r skills/* .autohand/skills/
+```
+
+Autohand Code 也支持通过 `autohand --skill-install` 安装已收录在 Autohand catalog 中的 skill，并可通过 `--project` 安装到当前项目。在本仓库收录前，请使用上面的复制或软链接方式。
+
 > 想保持与仓库同步可以用软链接代替 `cp -r`，例如：
 > ```bash
 > ln -s "$PWD"/skills/* ~/.openclaw/skills/
@@ -324,7 +338,7 @@ cp -r skills/* ~/.hermes/skills/
 
 > 把当前目录 `SenseNova-Skills/skills/` 下所有子目录复制到 OpenClaw 的 skill 目录（`~/.openclaw/skills/`）。完成后列出已安装的 skill 名称。
 
-把"OpenClaw"和路径换成 `hermes-agent` / `~/.hermes/skills/` 即可用于 hermes。Agent 会通过自己的 shell 工具完成 `mkdir` + `cp` + 列目录的动作，并把结果回报给你。
+把"OpenClaw"和路径按需换成 `hermes-agent` / `~/.hermes/skills/`、Autohand Code 全局 / `~/.autohand/skills/`，或 Autohand Code 项目级 / `.autohand/skills/`。Agent 会通过自己的 shell 工具完成 `mkdir` + `cp` + 列目录的动作，并把结果回报给你。
 
 > 这种方式适合按需挑选 skill，例如："只把 `sn-image-*` 和 `sn-deep-research` 这几个 skill 复制过去"。
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ After it finishes, **you may need to manually restart the agent service** before
 |-------|------------------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
 | [hermes-agent](https://github.com/NousResearch/hermes-agent) | `~/.hermes/skills/` |
+| [Autohand Code](https://github.com/autohandai/code-cli) | `~/.autohand/skills/` globally, or `<project>/.autohand/skills/` for one workspace |
 
 <details>
 <summary>Prefer to install manually?</summary>
@@ -65,7 +66,18 @@ mkdir -p ~/.openclaw/skills
 cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
-For Hermes, swap the target to `~/.hermes/skills/`.
+For Hermes, swap the target to `~/.hermes/skills/`. For Autohand Code, use `~/.autohand/skills/` globally or `<project>/.autohand/skills/` in a workspace:
+
+```bash
+mkdir -p ~/.autohand/skills
+cp -r SenseNova-Skills/skills/* ~/.autohand/skills/
+
+# Or install into the current project only
+mkdir -p .autohand/skills
+cp -r SenseNova-Skills/skills/* .autohand/skills/
+```
+
+Autohand Code also supports `autohand --skill-install` for cataloged skills, with `--project` for workspace-level installs. Until this repository is listed there, use the direct copy or symlink paths above.
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -54,6 +54,7 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 |--------|---------|
 | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/skills/` |
 | [hermes-agent](https://github.com/NousResearch/hermes-agent) | `~/.hermes/skills/` |
+| [Autohand Code](https://github.com/autohandai/code-cli) | 全局 `~/.autohand/skills/`，或当前项目 `<project>/.autohand/skills/` |
 
 <details>
 <summary>想手动安装？</summary>
@@ -66,7 +67,18 @@ mkdir -p ~/.openclaw/skills
 cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
-Hermes 把目录换成 `~/.hermes/skills/` 即可。
+Hermes 把目录换成 `~/.hermes/skills/` 即可。Autohand Code 可复制到全局 `~/.autohand/skills/`，或复制到当前项目的 `<project>/.autohand/skills/`：
+
+```bash
+mkdir -p ~/.autohand/skills
+cp -r SenseNova-Skills/skills/* ~/.autohand/skills/
+
+# 或只安装到当前项目
+mkdir -p .autohand/skills
+cp -r SenseNova-Skills/skills/* .autohand/skills/
+```
+
+Autohand Code 也支持通过 `autohand --skill-install` 安装已收录在 Autohand catalog 中的 skill，并可通过 `--project` 安装到当前项目。在本仓库收录前，请使用上面的复制或软链接方式。
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds Autohand Code as an additional Agent Skills install target in the README and install guide.

The new docs show:

- `~/.autohand/skills/` for global Autohand Code installs
- `<project>/.autohand/skills/` / `.autohand/skills/` for workspace installs
- conservative `autohand --skill-install` wording for cataloged skills only

The existing OpenClaw and hermes-agent recommended flow is unchanged.

## Validation

- `git diff --check`

I did not find a repo-level test/build command for these Markdown-only changes.
