### PR TITLE
docs: avoid overwriting manual skill installs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -302,17 +302,19 @@ OpenClaw:
 
 ```bash
 mkdir -p ~/.openclaw/skills
-cp -r skills/* ~/.openclaw/skills/
+cp -R -n skills/* ~/.openclaw/skills/
 ```
 
 hermes-agent:
 
 ```bash
 mkdir -p ~/.hermes/skills
-cp -r skills/* ~/.hermes/skills/
+cp -R -n skills/* ~/.hermes/skills/
 ```
 
-> Want skills to track this repo? Use symlinks instead of `cp -r`:
+`-n` keeps existing files in place, so local customizations are not overwritten silently. If you want to review each conflict interactively, replace `-n` with `-i`.
+
+> Want skills to track this repo? Use symlinks instead of copying the directories:
 > ```bash
 > ln -s "$PWD"/skills/* ~/.openclaw/skills/
 > ```
@@ -320,9 +322,9 @@ cp -r skills/* ~/.hermes/skills/
 
 ### 3.3 Option 2: ask the agent to install them
 
-Once your agent is up, send it the message below. It will use its own shell tool to do the `mkdir` + `cp` + listing for you.
+Once your agent is up, send it the message below. It will use its own shell tool to create the target directory, copy without overwriting existing files, and list the result for you.
 
-> Copy every subdirectory under `SenseNova-Skills/skills/` (in the current directory) into OpenClaw's skill directory (`~/.openclaw/skills/`). When you're done, list the installed skills.
+> Copy every subdirectory under `SenseNova-Skills/skills/` (in the current directory) into OpenClaw's skill directory (`~/.openclaw/skills/`) without overwriting existing files. When you're done, list the installed skills.
 
 Swap "OpenClaw" and the path for `hermes-agent` / `~/.hermes/skills/` to use this with hermes.
 

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -302,17 +302,19 @@ OpenClaw：
 
 ```bash
 mkdir -p ~/.openclaw/skills
-cp -r skills/* ~/.openclaw/skills/
+cp -R -n skills/* ~/.openclaw/skills/
 ```
 
 hermes-agent：
 
 ```bash
 mkdir -p ~/.hermes/skills
-cp -r skills/* ~/.hermes/skills/
+cp -R -n skills/* ~/.hermes/skills/
 ```
 
-> 想保持与仓库同步可以用软链接代替 `cp -r`，例如：
+`-n` 会保留已有文件，避免静默覆盖本地自定义内容。如需逐个确认冲突文件，可将 `-n` 替换为 `-i`。
+
+> 想保持与仓库同步可以用软链接代替复制目录，例如：
 > ```bash
 > ln -s "$PWD"/skills/* ~/.openclaw/skills/
 > ```
@@ -322,9 +324,9 @@ cp -r skills/* ~/.hermes/skills/
 
 启动 agent 后，把下面这条消息发给它：
 
-> 把当前目录 `SenseNova-Skills/skills/` 下所有子目录复制到 OpenClaw 的 skill 目录（`~/.openclaw/skills/`）。完成后列出已安装的 skill 名称。
+> 把当前目录 `SenseNova-Skills/skills/` 下所有子目录复制到 OpenClaw 的 skill 目录（`~/.openclaw/skills/`），不要覆盖已有文件。完成后列出已安装的 skill 名称。
 
-把"OpenClaw"和路径换成 `hermes-agent` / `~/.hermes/skills/` 即可用于 hermes。Agent 会通过自己的 shell 工具完成 `mkdir` + `cp` + 列目录的动作，并把结果回报给你。
+把"OpenClaw"和路径换成 `hermes-agent` / `~/.hermes/skills/` 即可用于 hermes。Agent 会通过自己的 shell 工具创建目标目录、执行不覆盖已有文件的复制，并把结果回报给你。
 
 > 这种方式适合按需挑选 skill，例如："只把 `sn-image-*` 和 `sn-deep-research` 这几个 skill 复制过去"。
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ These skills are designed to run inside an [Agent Skills](https://agentskills.io
 - **Recommended LLM**: pair them with the **[SenseNova Platform API](https://platform.sensenova.cn/token-plan)** — a free token plan is available.
 - **Install & configure**: follow the full walkthrough in **[`INSTALL.md`](INSTALL.md)**.
 
-**Recommended: let the agent install the skills for you.** Hand it the repo URL and ask it to clone and drop the skills into the right directory — for example:
+**Recommended: let the agent install the skills for you.** Hand it the repo URL and ask it to clone and copy the skills into the right directory without overwriting existing files — for example:
 
-> *"Please install SenseNova-Skills from https://github.com/OpenSenseNova/SenseNova-Skills into your skills directory."*
+> *"Please install SenseNova-Skills from https://github.com/OpenSenseNova/SenseNova-Skills into your skills directory without overwriting existing files."*
 
 After it finishes, **you may need to manually restart the agent service** before the new skills are picked up.
 
@@ -57,15 +57,22 @@ After it finishes, **you may need to manually restart the agent service** before
 <details>
 <summary>Prefer to install manually?</summary>
 
-Clone this repository, then copy the subdirectories under `skills/` into the target directory yourself:
+Clone this repository, then copy the subdirectories under `skills/` into the target directory without replacing files that are already installed:
 
 ```bash
 git clone https://github.com/OpenSenseNova/SenseNova-Skills.git --depth=1
 mkdir -p ~/.openclaw/skills
-cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
+cp -R -n SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
-For Hermes, swap the target to `~/.hermes/skills/`.
+For Hermes, use its skills directory:
+
+```bash
+mkdir -p ~/.hermes/skills
+cp -R -n SenseNova-Skills/skills/* ~/.hermes/skills/
+```
+
+The `-n` flag preserves existing files, which helps avoid overwriting local customizations. If you want to review each conflict interactively, replace `-n` with `-i`.
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,9 +44,9 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 - **推荐 LLM**：配合使用 **[SenseNova 平台 API](https://platform.sensenova.cn/token-plan)**（提供免费 token 套餐）。
 - **安装与配置**：完整流程请参考 **[`INSTALL_CN.md`](INSTALL_CN.md)**。
 
-**推荐做法：直接让 agent 帮你装好这些 skill。** 把仓库地址交给它，让它自己克隆并把内容拷贝到目标目录，例如：
+**推荐做法：直接让 agent 帮你装好这些 skill。** 把仓库地址交给它，让它自己克隆并把内容拷贝到目标目录，同时不要覆盖已有文件，例如：
 
-> *"请帮我把 https://github.com/OpenSenseNova/SenseNova-Skills 安装到你的 skills 目录。"*
+> *"请帮我把 https://github.com/OpenSenseNova/SenseNova-Skills 安装到你的 skills 目录，不要覆盖已有文件。"*
 
 安装完成后，**可能需要手动重启 agent 服务**，新 skill 才会被加载。
 
@@ -58,15 +58,22 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 <details>
 <summary>想手动安装？</summary>
 
-克隆本仓库，然后把 `skills/` 下的子目录自行复制（或软链接）到目标目录：
+克隆本仓库，然后把 `skills/` 下的子目录复制到目标目录，同时避免替换已经安装的文件：
 
 ```bash
 git clone https://github.com/OpenSenseNova/SenseNova-Skills.git --depth=1
 mkdir -p ~/.openclaw/skills
-cp -r SenseNova-Skills/skills/* ~/.openclaw/skills/
+cp -R -n SenseNova-Skills/skills/* ~/.openclaw/skills/
 ```
 
-Hermes 把目录换成 `~/.hermes/skills/` 即可。
+Hermes 使用它自己的 skill 目录：
+
+```bash
+mkdir -p ~/.hermes/skills
+cp -R -n SenseNova-Skills/skills/* ~/.hermes/skills/
+```
+
+`-n` 会保留已有文件，避免覆盖本地自定义内容。如需逐个确认冲突文件，可将 `-n` 替换为 `-i`。
 
 </details>
 


### PR DESCRIPTION
## Summary
- update README and INSTALL manual install commands to use `cp -R -n` so existing skill files are preserved
- add explicit Hermes directory creation in README manual install instructions
- align English and Chinese docs, including agent-install prompts, around no-overwrite installs

## Validation
- `git diff --check -- README.md README_CN.md INSTALL.md INSTALL_CN.md`
- `rg -n "cp -r|cp -R|overwrit|覆盖|~/.openclaw/skills|~/.hermes/skills" README.md README_CN.md INSTALL.md INSTALL_CN.md`
- local smoke test for `cp -R -n` preserving existing files while copying new skill directories

Closes #126