### PR TITLE
fix(nano_banana): surface Gemini finishReason

### DIFF
--- a/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py
@@ -23,6 +23,12 @@ DEFAULT_ASPECT_RATIO = "16:9"
 DEFAULT_POLL_INTERVAL = 5.0
 OUTPUT_DIR = Path("/tmp/openclaw-sn-image")
 
+# Gemini finishReason values that indicate content was blocked by safety/policy filters.
+# See: https://ai.google.dev/api/generate-content#FinishReason
+SAFETY_BLOCK_FINISH_REASONS = frozenset(
+    {"SAFETY", "IMAGE_SAFETY", "PROHIBITED_CONTENT", "BLOCKLIST", "SPII", "RECITATION"}
+)
+
 
 class NanoBananaText2ImageClient(T2IBaseClient):
     """Async client for Google Nano Banana API."""
@@ -157,10 +163,17 @@ class NanoBananaText2ImageClient(T2IBaseClient):
         try:
             images = data["images"]
             if not images:
+                reasons = data.get("finish_reasons") or []
+                if any(r in SAFETY_BLOCK_FINISH_REASONS for r in reasons):
+                    error_msg = f"Image blocked by safety filter (finishReason={reasons})"
+                elif reasons:
+                    error_msg = f"No image generated from the model (finishReason={reasons})"
+                else:
+                    error_msg = "No image generated from the model"
                 return {
                     "status": "failed",
                     "error_type": "EmptyResponse",
-                    "error": "No image generated from the model",
+                    "error": error_msg,
                 }
             image, mime_type = images[-1]
             image_bytes = base64.b64decode(image)
@@ -275,7 +288,7 @@ class NanoBananaText2ImageClient(T2IBaseClient):
         for c in candidates:
             content: dict[str, Any] = c.get("content") or {}
             parts: list[dict[str, Any]] = content.get("parts") or []
-            if f_reason := content.get("finishReason"):
+            if f_reason := c.get("finishReason"):
                 finish_reasons.append(f_reason)
             for p in parts:
                 inline_data: dict[str, Any] = p.get("inlineData", {})


### PR DESCRIPTION
## Summary

- read Gemini `finishReason` from the candidate object instead of `content`
- include finish reasons in empty-image errors
- call out safety/policy blocked responses with a clearer error message

## Root cause

Gemini returns `finishReason` as a sibling of `content` on each candidate, so reading it from `content` always produced an empty `finish_reasons` list.

## Validation

- `python3 -m py_compile skills/sn-image-base/scripts/sn_image_base/generation/nano_banana.py`
- inline behavior check for `parse_response()` and the safety-filter empty response path

Fixes #109