### PR TITLE
fix(sn-search-academic): prevent XXE in pmc_paper.py

### DIFF
--- a/skills/sn-search-academic/requirements.txt
+++ b/skills/sn-search-academic/requirements.txt
@@ -1,4 +1,5 @@
 httpx>=0.27
+defusedxml>=0.7.1
 arxiv>=2.0.0
 beautifulsoup4>=4.12.3
 semanticscholar

--- a/skills/sn-search-academic/scripts/pmc_paper.py
+++ b/skills/sn-search-academic/scripts/pmc_paper.py
@@ -17,7 +17,7 @@ PMC 论文全文章节阅读器。
 import argparse
 import re
 import sys
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from typing import Any
 
 


### PR DESCRIPTION
## Summary
Harden input handling in `skills/sn-search-academic/scripts/pmc_paper.py` (flagged by semgrep).

Updated the PR title to match the repository's Conventional Commits requirements.

The change itself remains intentionally minimal: `pmc_paper.py` parses XML from an external
NCBI response, so the native XML parser is replaced with `defusedxml.ElementTree` to harden
the XML parsing boundary against XXE-related attacks, while preserving the existing
ElementTree API and behavior for valid XML. `defusedxml` was also added to the skill's
`requirements.txt` so the dependency is installed through the existing dependency mechanism.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410` |
| **File** | `skills/sn-search-academic/scripts/pmc_paper.py:20` |
| **Assessment** | Defensive hardening |

**Description**: Found use of the native Python XML libraries, which is vulnerable to XML external entity (XXE)
attacks. The Python documentation recommends the 'defusedxml' library instead. Use 'defusedxml'.
See https://github.com/tiran/defusedxml for more information.

## Changes
- `skills/sn-search-academic/scripts/pmc_paper.py`
- `skills/sn-search-academic/requirements.txt`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
