### PR TITLE
fix: address security dependency findings for issue #150

### DIFF
--- a/skills/sn-image-base/requirements.txt
+++ b/skills/sn-image-base/requirements.txt
@@ -1,3 +1,3 @@
 httpx>=0.25.0
-pillow>=10.0.0
+pillow>=11.3.0
 python-dotenv>=1.0.0

--- a/skills/sn-ppt-standard/scripts/export_pptx/package-lock.json
+++ b/skills/sn-ppt-standard/scripts/export_pptx/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "echarts": "^5.4.3",
-        "playwright": "^1.50.0",
+        "playwright": "1.58.2",
         "pptxgenjs": "^3.12.0"
       }
     },

--- a/skills/sn-ppt-standard/scripts/export_pptx/package.json
+++ b/skills/sn-ppt-standard/scripts/export_pptx/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "pptxgenjs": "^3.12.0",
-    "playwright": "^1.50.0",
+    "playwright": "1.58.2",
     "echarts": "^5.4.3"
   }
 }


### PR DESCRIPTION
## 背景

本 PR 修复 issue #150 中提到的依赖安全问题。

Fixes #150

## 修改内容

- 将 `skills/sn-image-base/requirements.txt` 中的 `pillow` 下限从 `>=10.0.0` 提升到 `>=11.3.0`
- 将 `skills/sn-ppt-standard/scripts/export_pptx/package.json` 中的 `playwright` 声明版本调整为 `1.58.2`
- 同步更新 `skills/sn-ppt-standard/scripts/export_pptx/package-lock.json` 顶层依赖声明

## 修改原因

扫描结果指出：
- `sn-image-base` 中 `pillow==10.0.0` 存在已知 CVE
- `sn-ppt-standard` 中 `playwright==1.50.0` 存在安全风险

其中：
- `sn-image-base` 原先的版本范围仍可能解析到存在风险的 Pillow 版本
- `sn-ppt-standard` 的 lockfile 实际已解析到 `1.58.2`，但 `package.json` 仍声明为 `^1.50.0`，容易造成扫描误报或声明与实际版本不一致

## 验证情况

- 已确认仅修改 3 个目标文件
- 已校验 `package.json` 和 `package-lock.json` JSON 格式合法

## 说明

- 当前环境下 `skills/sn-ppt-standard/scripts/export_pptx` 没有本地 `node_modules`，因此未执行 `npm test`