### PR TITLE
docs: update international SenseNova API setup in English docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,9 +2,11 @@
 
 English | [简体中文](INSTALL_CN.md)
 
-This guide walks you through installing [OpenClaw](https://openclaw.ai/) or [hermes-agent](https://github.com/NousResearch/hermes-agent) on Windows / macOS / Linux, wiring it up to a [SenseNova](https://platform.sensenova.cn/) LLM, and loading the skills in this repository — giving you a fully working skill-driven agent.
+This guide walks you through installing [OpenClaw](https://openclaw.ai/) or [hermes-agent](https://github.com/NousResearch/hermes-agent) on Windows / macOS / Linux, wiring it up to the [SenseNova international API](https://platform.sensenova.ai/docs), and loading the skills in this repository — giving you a fully working skill-driven agent.
 
 > Pick **either** agent. Both OpenClaw and hermes-agent follow the [Agent Skills](https://agentskills.io/) convention, so the skills in this repo work in either runtime without modification.
+>
+> This English guide targets the international SenseNova API. The Chinese guide keeps the mainland China token-plan flow.
 
 ---
 
@@ -14,11 +16,13 @@ Both agents below will use the same three values:
 
 | Field      | Value                                                                                                          |
 | ---------- | -------------------------------------------------------------------------------------------------------------- |
-| Base URL   | `https://token.sensenova.cn/v1`                                                                                |
-| API key    | Get one for free at [SenseNova Console · token-plan](https://platform.sensenova.cn/token-plan) and copy it. |
-| Model name | `sensenova-6.7-flash-lite`                                                                                     |
+| Base URL   | `https://token.sensenova.ai/v1`                                                                                |
+| API key    | Follow the [official docs](https://platform.sensenova.ai/docs): create an account, verify your email, then create a key in Console → API Keys. |
+| Model name | `sensenova-6.8-flash-lite`                                                                                     |
 
 > The endpoint speaks the OpenAI-compatible protocol, so it fits any "OpenAI compatible" provider slot.
+>
+> As of August 12, 2026, the official international docs use `sensenova-6.8-flash-lite`. They also state that calls made with `sensenova-6.7-flash-lite` are compatibility-routed to `sensenova-6.8-flash-lite` through August 31, 2026.
 
 ---
 
@@ -164,7 +168,7 @@ Follow the prompts as shown below. Use the API key from §0, and configure at le
 │  Custom Provider
 │
 ◇  API Base URL
-│  https://token.sensenova.cn/v1
+│  https://token.sensenova.ai/v1
 │
 ◇  How do you want to provide this API key?
 │  Paste API key now
@@ -176,12 +180,12 @@ Follow the prompts as shown below. Use the API key from §0, and configure at le
 │  OpenAI-compatible
 │
 ◇  Model ID
-│  sensenova-6.7-flash-lite
+│  sensenova-6.8-flash-lite
 │
 ◇  Verification successful.
 │
 ◇  Endpoint ID
-│  custom-token-sensenova-cn
+│  custom-token-sensenova-ai
 │
 ◇  Select channel (QuickStart)
 │  Skip for now
@@ -253,10 +257,10 @@ Fastest path — use `hermes config set`:
 
 ```bash
 hermes config set model.provider custom
-hermes config set model.base_url https://token.sensenova.cn/v1
+hermes config set model.base_url https://token.sensenova.ai/v1
 hermes config set model.api_key "<your API key>"
-hermes config set model.name sensenova-6.7-flash-lite
-hermes config set model.default custom/sensenova-6.7-flash-lite
+hermes config set model.name sensenova-6.8-flash-lite
+hermes config set model.default custom/sensenova-6.8-flash-lite
 ```
 
 > The last line is required — without `model.default`, hermes still routes through whatever was configured at install time (e.g. `anthropic/claude-opus-4.6`) and `hermes -z "..."` fails with `HTTP 404: model is not found`. If you'd rather not run individual commands, use `hermes setup` or `hermes model` (below) instead — both update `model.default` for you.
@@ -273,9 +277,9 @@ hermes model        # just the LLM provider step
 
 When the wizard asks for a provider, pick `custom (OpenAI-compatible)` and enter:
 
-- Base URL: `https://token.sensenova.cn/v1`
+- Base URL: `https://token.sensenova.ai/v1`
 - API key: the one you generated above
-- Model name: `sensenova-6.7-flash-lite`
+- Model name: `sensenova-6.8-flash-lite`
 
 #### 2.B.4 Verify the LLM connection
 
@@ -354,5 +358,6 @@ If the agent enumerates skills like `sn-infographic`, `sn-ppt-entry`, and `sn-de
 - **`wsl --install` not found**: needs Windows 10 22H2+ / Windows 11, run PowerShell as Administrator.
 - **Node version too low**: `node -v` must be ≥ 22.14. Switch with nvm: `nvm install 24 && nvm use 24`.
 - **`openclaw doctor` / `hermes doctor` complains**: follow the report's hints — install whatever's missing.
-- **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); confirm the key still has free quota in [token-plan](https://platform.sensenova.cn/token-plan).
+- **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); for the international API, make sure you verified your email, created the key in Console → API Keys, and are using `https://token.sensenova.ai/v1`.
+- **Provider verification fails in OpenClaw / Hermes**: if you are following this English guide, do not use the mainland `.cn` endpoint from older screenshots or Chinese docs. Use `https://token.sensenova.ai/v1` with `sensenova-6.8-flash-lite`.
 - **Slow `curl` inside WSL2**: check the WSL2 networking mode (`wsl --status`); switch to `mirrored` networking or use a proxy if needed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,6 +59,7 @@ OpenClaw recommends running under WSL2 on Windows; hermes-agent **only supports*
 Requirements: Windows 10 22H2+ or Windows 11.
 
 1. Open PowerShell **as Administrator**:
+
    ```powershell
    wsl --install
    ```
@@ -67,6 +68,7 @@ Requirements: Windows 10 22H2+ or Windows 11.
 2. Reboot the machine.
 3. After reboot, the Ubuntu terminal launches automatically — set your UNIX username and password as prompted.
 4. Verify the WSL version and distribution:
+
    ```powershell
    wsl -l -v
    ```
@@ -204,10 +206,10 @@ Follow the prompts as shown below. Use the API key from §0, and configure at le
 │  Skip for now
 ```
 
-Depending on your region, use one of the following pair:
+Depending on your region, use one of the following base URL:
 
-- International: `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`
-- Mainland China: `https://token.sensenova.cn/v1` + `sensenova-6.8-flash-lite`
+- International: `https://token.sensenova.ai/v1`
+- Mainland China: `https://token.sensenova.cn/v1`
 
 #### 2.A.5 Verify the LLM connection
 
@@ -293,9 +295,9 @@ hermes model        # just the LLM provider step
 
 When the wizard asks for a provider, pick `custom (OpenAI-compatible)` and enter:
 
-- Base URL `https://token.sensenova.ai/v1`, model `sensenova-6.8-flash-lite`(for international users)
-- Base URL `https://token.sensenova.cn/v1`, model `sensenova-6.8-flash-lite`(for mainland China users)
-- API key: use the key generated from the same region's docs page
+- Base URL:`https://token.sensenova.ai/v1`(for international users), or `https://token.sensenova.cn/v1` (for mainland China users)
+- API key: use the key you generated above
+- Model name:`sensenova-6.8-flash-lite`
 
 #### 2.B.4 Verify the LLM connection
 
@@ -377,5 +379,5 @@ If the agent enumerates skills like `sn-infographic`, `sn-ppt-entry`, and `sn-de
 - **Node version too low**: `node -v` must be ≥ 22.14. Switch with nvm: `nvm install 24 && nvm use 24`.
 - **`openclaw doctor` / `hermes doctor` complains**: follow the report's hints — install whatever's missing.
 - **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); make sure the key, base URL, and model all come from the same region.
-- **Provider verification fails in OpenClaw / Hermes**: verify that you did not mix the two regional setups. Use either `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`, or `https://token.sensenova.cn/v1` + `sensenova-6.8-flash-lite`.
+- **Provider verification fails in OpenClaw / Hermes**: verify that you choose the setups that match your region, whether you are an international user (`https://token.sensenova.ai/v1`) or a mainland China user (`https://token.sensenova.cn/v1`).
 - **Slow `curl` inside WSL2**: check the WSL2 networking mode (`wsl --status`); switch to `mirrored` networking or use a proxy if needed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,23 +2,22 @@
 
 English | [简体中文](INSTALL_CN.md)
 
-This guide walks you through installing [OpenClaw](https://openclaw.ai/) or [hermes-agent](https://github.com/NousResearch/hermes-agent) on Windows / macOS / Linux, wiring it up to the [SenseNova international API](https://platform.sensenova.ai/docs), and loading the skills in this repository — giving you a fully working skill-driven agent.
+This guide walks you through installing [OpenClaw](https://openclaw.ai/) or [hermes-agent](https://github.com/NousResearch/hermes-agent) on Windows / macOS / Linux, wiring it up to SenseNova, and loading the skills in this repository — giving you a fully working skill-driven agent.
 
 > Pick **either** agent. Both OpenClaw and hermes-agent follow the [Agent Skills](https://agentskills.io/) convention, so the skills in this repo work in either runtime without modification.
 >
-> This English guide targets the international SenseNova API. The Chinese guide keeps the mainland China token-plan flow.
+> This guide includes both the international and mainland China SenseNova API flows. Use one region consistently for the docs page, API key, base URL, and model name.
 
 ---
 
 ## 0. Prepare your SenseNova API key and endpoint
 
-Both agents below will use the same three values:
+Both agents below need the same three values, but the exact pair depends on which SenseNova region you are using:
 
-| Field      | Value                                                                                                          |
-| ---------- | -------------------------------------------------------------------------------------------------------------- |
-| Base URL   | `https://token.sensenova.ai/v1`                                                                                |
-| API key    | Follow the [official docs](https://platform.sensenova.ai/docs): create an account, verify your email, then create a key in Console → API Keys. |
-| Model name | `sensenova-6.8-flash-lite`                                                                                     |
+| Region | Docs / key signup | Base URL | Model name |
+| ---------- | ---------- | ---------- | ---------- |
+| International | Follow [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs): create an account, verify your email, then create a key in Console → API Keys | `https://token.sensenova.ai/v1` | `sensenova-6.8-flash-lite` |
+| Mainland China | Use [platform.sensenova.cn/token-plan](https://platform.sensenova.cn/token-plan) to apply for a token-plan key | `https://token.sensenova.cn/v1` | `sensenova-6.7-flash-lite` |
 
 > The endpoint speaks the OpenAI-compatible protocol, so it fits any "OpenAI compatible" provider slot.
 >
@@ -45,7 +44,7 @@ Pre-built installers live on the [GitHub Releases page](https://github.com/OpenS
 | macOS | [`-macos-universal.pkg` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest) | Double-click, then complete the macOS wizard for product selection and LLM configuration; on finish it opens the OpenClaw Gateway Terminal + dashboard, and/or the Hermes Terminal as selected. |
 | Linux | [`-linux.sh` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest), or the one-liner on the right | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`, or paste `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` — either way the shell that ran the installer is handed over to the agent via `exec`. |
 
-When the installer asks for the LLM provider, choose **Custom (OpenAI-compatible)** and feed in the three values from §0 (Base URL, API key, model name). If you're in a China-region network, set `AGENTPACK_CN=1` to enable the GitHub mirror fallbacks.
+When the installer asks for the LLM provider, choose **Custom (OpenAI-compatible)** and feed in one matching set of values from §0 (Base URL, API key, model name). If you're in a China-region network, set `AGENTPACK_CN=1` to enable the GitHub mirror fallbacks.
 
 > **Skills are already bundled** — Agent Pack ships with the SenseNova-Skills committed inside each product's `skills/` directory and installs them as part of the normal install. **You do not need to follow §3 ("Load this repo's skills")** — they're already loaded.
 
@@ -205,6 +204,11 @@ Follow the prompts as shown below. Use the API key from §0, and configure at le
 │  Skip for now
 ```
 
+For the two SenseNova regions, use one matching pair:
+
+- International: `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`
+- Mainland China: `https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`
+
 #### 2.A.5 Verify the LLM connection
 
 ```bash
@@ -253,7 +257,9 @@ hermes doctor
 
 #### 2.B.3 Configure the SenseNova LLM
 
-Fastest path — use `hermes config set`:
+Fastest path — use `hermes config set`.
+
+International:
 
 ```bash
 hermes config set model.provider custom
@@ -261,6 +267,16 @@ hermes config set model.base_url https://token.sensenova.ai/v1
 hermes config set model.api_key "<your API key>"
 hermes config set model.name sensenova-6.8-flash-lite
 hermes config set model.default custom/sensenova-6.8-flash-lite
+```
+
+Mainland China:
+
+```bash
+hermes config set model.provider custom
+hermes config set model.base_url https://token.sensenova.cn/v1
+hermes config set model.api_key "<your API key>"
+hermes config set model.name sensenova-6.7-flash-lite
+hermes config set model.default custom/sensenova-6.7-flash-lite
 ```
 
 > The last line is required — without `model.default`, hermes still routes through whatever was configured at install time (e.g. `anthropic/claude-opus-4.6`) and `hermes -z "..."` fails with `HTTP 404: model is not found`. If you'd rather not run individual commands, use `hermes setup` or `hermes model` (below) instead — both update `model.default` for you.
@@ -275,11 +291,11 @@ hermes setup        # full setup wizard
 hermes model        # just the LLM provider step
 ```
 
-When the wizard asks for a provider, pick `custom (OpenAI-compatible)` and enter:
+When the wizard asks for a provider, pick `custom (OpenAI-compatible)` and enter one matching set:
 
-- Base URL: `https://token.sensenova.ai/v1`
-- API key: the one you generated above
-- Model name: `sensenova-6.8-flash-lite`
+- International: Base URL `https://token.sensenova.ai/v1`, model `sensenova-6.8-flash-lite`
+- Mainland China: Base URL `https://token.sensenova.cn/v1`, model `sensenova-6.7-flash-lite`
+- API key: use the key generated from the same region's docs page
 
 #### 2.B.4 Verify the LLM connection
 
@@ -358,6 +374,6 @@ If the agent enumerates skills like `sn-infographic`, `sn-ppt-entry`, and `sn-de
 - **`wsl --install` not found**: needs Windows 10 22H2+ / Windows 11, run PowerShell as Administrator.
 - **Node version too low**: `node -v` must be ≥ 22.14. Switch with nvm: `nvm install 24 && nvm use 24`.
 - **`openclaw doctor` / `hermes doctor` complains**: follow the report's hints — install whatever's missing.
-- **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); for the international API, make sure you verified your email, created the key in Console → API Keys, and are using `https://token.sensenova.ai/v1`.
-- **Provider verification fails in OpenClaw / Hermes**: if you are following this English guide, do not use the mainland `.cn` endpoint from older screenshots or Chinese docs. Use `https://token.sensenova.ai/v1` with `sensenova-6.8-flash-lite`.
+- **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); make sure the key, base URL, and model all come from the same region.
+- **Provider verification fails in OpenClaw / Hermes**: verify that you did not mix the two regional setups. Use either `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`, or `https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`.
 - **Slow `curl` inside WSL2**: check the WSL2 networking mode (`wsl --status`); switch to `mirrored` networking or use a proxy if needed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,23 +5,21 @@ English | [简体中文](INSTALL_CN.md)
 This guide walks you through installing [OpenClaw](https://openclaw.ai/) or [hermes-agent](https://github.com/NousResearch/hermes-agent) on Windows / macOS / Linux, wiring it up to SenseNova, and loading the skills in this repository — giving you a fully working skill-driven agent.
 
 > Pick **either** agent. Both OpenClaw and hermes-agent follow the [Agent Skills](https://agentskills.io/) convention, so the skills in this repo work in either runtime without modification.
->
-> This guide includes both the international and mainland China SenseNova API flows. Use one region consistently for the docs page, API key, base URL, and model name.
 
 ---
 
 ## 0. Prepare your SenseNova API key and endpoint
 
-Both agents below need the same three values, but the exact pair depends on which SenseNova region you are using:
+Depending on which region you are in, use the corresponding base URL / API key / model name from the table below. The same three values wil be used for both agents ([OpenClaw](https://openclaw.ai/) and [hermes-agent](https://github.com/NousResearch/hermes-agent)).
 
-| Region | Docs / key signup | Base URL | Model name |
-| ---------- | ---------- | ---------- | ---------- |
-| International | Follow [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs): create an account, verify your email, then create a key in Console → API Keys | `https://token.sensenova.ai/v1` | `sensenova-6.8-flash-lite` |
-| Mainland China | Use [platform.sensenova.cn/token-plan](https://platform.sensenova.cn/token-plan) to apply for a token-plan key | `https://token.sensenova.cn/v1` | `sensenova-6.7-flash-lite` |
+| Region         | Docs / key signup                                                                                                                                     | Base URL                          | Model name                   |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------- |
+| International  | Follow[platform.sensenova.ai/docs](https://platform.sensenova.ai/docs): create an account, verify your email, then create a key in Console → API Keys | `https://token.sensenova.ai/v1` | `sensenova-6.8-flash-lite` |
+| Mainland China | Use[platform.sensenova.cn/token-plan](https://platform.sensenova.cn/token-plan) to apply for a token-plan key                                          | `https://token.sensenova.cn/v1` | `sensenova-6.8-flash-lite` |
 
 > The endpoint speaks the OpenAI-compatible protocol, so it fits any "OpenAI compatible" provider slot.
 >
-> As of August 12, 2026, the official international docs use `sensenova-6.8-flash-lite`. They also state that calls made with `sensenova-6.7-flash-lite` are compatibility-routed to `sensenova-6.8-flash-lite` through August 31, 2026.
+> As of August 12, 2026, the official international docs use `sensenova-6.8-flash-lite`. Calls made with `sensenova-6.7-flash-lite` are compatibility-routed to `sensenova-6.8-flash-lite` through August 31, 2026.
 
 ---
 
@@ -38,13 +36,13 @@ If you'd rather skip the manual steps below, [Agent Pack](https://github.com/Ope
 
 Pre-built installers live on the [GitHub Releases page](https://github.com/OpenSenseNova/agent_pack/releases/latest):
 
-| Platform | Download | How to use |
-|----------|----------|------------|
-| Windows | [`-windows-x64.exe` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest) | Double-click and follow the wizard; installation runs inside WSL2, and the PowerShell window is taken over by the installed agent when setup finishes. |
-| macOS | [`-macos-universal.pkg` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest) | Double-click, then complete the macOS wizard for product selection and LLM configuration; on finish it opens the OpenClaw Gateway Terminal + dashboard, and/or the Hermes Terminal as selected. |
-| Linux | [`-linux.sh` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest), or the one-liner on the right | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`, or paste `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` — either way the shell that ran the installer is handed over to the agent via `exec`. |
+| Platform | Download                                                                                                                           | How to use                                                                                                                                                                                                                                                             |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows  | [`-windows-x64.exe` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest)                         | Double-click and follow the wizard; installation runs inside WSL2, and the PowerShell window is taken over by the installed agent when setup finishes.                                                                                                                 |
+| macOS    | [`-macos-universal.pkg` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest)                     | Double-click, then complete the macOS wizard for product selection and LLM configuration; on finish it opens the OpenClaw Gateway Terminal + dashboard, and/or the Hermes Terminal as selected.                                                                        |
+| Linux    | [`-linux.sh` from the latest release](https://github.com/OpenSenseNova/agent_pack/releases/latest), or the one-liner on the right | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`, or paste `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` — either way the shell that ran the installer is handed over to the agent via `exec`. |
 
-When the installer asks for the LLM provider, choose **Custom (OpenAI-compatible)** and feed in one matching set of values from §0 (Base URL, API key, model name). If you're in a China-region network, set `AGENTPACK_CN=1` to enable the GitHub mirror fallbacks.
+When the installer asks for the LLM provider, choose **Custom (OpenAI-compatible)** and feed in the three values from §0 (Base URL, API key, model name). If you're in a China-region network, set `AGENTPACK_CN=1` to enable the GitHub mirror fallbacks.
 
 > **Skills are already bundled** — Agent Pack ships with the SenseNova-Skills committed inside each product's `skills/` directory and installs them as part of the normal install. **You do not need to follow §3 ("Load this repo's skills")** — they're already loaded.
 
@@ -64,6 +62,7 @@ Requirements: Windows 10 22H2+ or Windows 11.
    ```powershell
    wsl --install
    ```
+
    This enables the required Windows features and installs the default Ubuntu distribution.
 2. Reboot the machine.
 3. After reboot, the Ubuntu terminal launches automatically — set your UNIX username and password as prompted.
@@ -71,6 +70,7 @@ Requirements: Windows 10 22H2+ or Windows 11.
    ```powershell
    wsl -l -v
    ```
+
    The `VERSION` column should read `2`.
 
 From here on, run every command in the **Ubuntu (WSL2) terminal**, not in PowerShell.
@@ -113,7 +113,7 @@ OpenClaw needs **Node.js 24 (recommended) or 22.14+**.
 
 Pick any one option:
 
-- **Official installer**: download the LTS from <https://nodejs.org/>.
+- **Official installer**: download the LTS from [https://nodejs.org/](https://nodejs.org/).
 - **Homebrew (macOS)**: `brew install node@24`
 - **nvm (recommended for Linux/WSL2/macOS)**:
   ```bash
@@ -204,10 +204,10 @@ Follow the prompts as shown below. Use the API key from §0, and configure at le
 │  Skip for now
 ```
 
-For the two SenseNova regions, use one matching pair:
+Depending on your region, use one of the following pair:
 
 - International: `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`
-- Mainland China: `https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`
+- Mainland China: `https://token.sensenova.cn/v1` + `sensenova-6.8-flash-lite`
 
 #### 2.A.5 Verify the LLM connection
 
@@ -275,8 +275,8 @@ Mainland China:
 hermes config set model.provider custom
 hermes config set model.base_url https://token.sensenova.cn/v1
 hermes config set model.api_key "<your API key>"
-hermes config set model.name sensenova-6.7-flash-lite
-hermes config set model.default custom/sensenova-6.7-flash-lite
+hermes config set model.name sensenova-6.8-flash-lite
+hermes config set model.default custom/sensenova-6.8-flash-lite
 ```
 
 > The last line is required — without `model.default`, hermes still routes through whatever was configured at install time (e.g. `anthropic/claude-opus-4.6`) and `hermes -z "..."` fails with `HTTP 404: model is not found`. If you'd rather not run individual commands, use `hermes setup` or `hermes model` (below) instead — both update `model.default` for you.
@@ -291,10 +291,10 @@ hermes setup        # full setup wizard
 hermes model        # just the LLM provider step
 ```
 
-When the wizard asks for a provider, pick `custom (OpenAI-compatible)` and enter one matching set:
+When the wizard asks for a provider, pick `custom (OpenAI-compatible)` and enter:
 
-- International: Base URL `https://token.sensenova.ai/v1`, model `sensenova-6.8-flash-lite`
-- Mainland China: Base URL `https://token.sensenova.cn/v1`, model `sensenova-6.7-flash-lite`
+- Base URL `https://token.sensenova.ai/v1`, model `sensenova-6.8-flash-lite`(for international users)
+- Base URL `https://token.sensenova.cn/v1`, model `sensenova-6.8-flash-lite`(for mainland China users)
 - API key: use the key generated from the same region's docs page
 
 #### 2.B.4 Verify the LLM connection
@@ -333,9 +333,11 @@ cp -r skills/* ~/.hermes/skills/
 ```
 
 > Want skills to track this repo? Use symlinks instead of `cp -r`:
+>
 > ```bash
 > ln -s "$PWD"/skills/* ~/.openclaw/skills/
 > ```
+>
 > Then `git pull` automatically pulls in skill updates.
 
 ### 3.3 Option 2: ask the agent to install them
@@ -375,5 +377,5 @@ If the agent enumerates skills like `sn-infographic`, `sn-ppt-entry`, and `sn-de
 - **Node version too low**: `node -v` must be ≥ 22.14. Switch with nvm: `nvm install 24 && nvm use 24`.
 - **`openclaw doctor` / `hermes doctor` complains**: follow the report's hints — install whatever's missing.
 - **LLM returns 401 / 403**: double-check the LLM API key stored in your config (`openclaw config get models.providers.custom` for OpenClaw, or `hermes config get model.api_key` for hermes-agent); make sure the key, base URL, and model all come from the same region.
-- **Provider verification fails in OpenClaw / Hermes**: verify that you did not mix the two regional setups. Use either `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`, or `https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`.
+- **Provider verification fails in OpenClaw / Hermes**: verify that you did not mix the two regional setups. Use either `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`, or `https://token.sensenova.cn/v1` + `sensenova-6.8-flash-lite`.
 - **Slow `curl` inside WSL2**: check the WSL2 networking mode (`wsl --status`); switch to `mirrored` networking or use a proxy if needed.

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -10,7 +10,7 @@
 
 ## 0. 先准备 SenseNova API Key 与端点
 
-后续两种 agent 都需要下面这组配置，但具体值取决于你使用的是海外版还是中国内地版：
+请根据你所在的区域（海外/中国内地）选用对应的API配置，这组配置后续将同时用于[OpenClaw](https://openclaw.ai/) 和 [hermes-agent](https://github.com/NousResearch/hermes-agent)：
 
 | 地区     | 文档 / 申请入口                                                                                                           | Base URL                          | 模型名                       |
 | -------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------- |
@@ -57,6 +57,7 @@ OpenClaw 在 Windows 上推荐 WSL2，hermes-agent 在 Windows 上**仅支持** 
 要求：Windows 10 22H2+ 或 Windows 11。
 
 1. 以**管理员身份**打开 PowerShell：
+
    ```powershell
    wsl --install
    ```
@@ -65,6 +66,7 @@ OpenClaw 在 Windows 上推荐 WSL2，hermes-agent 在 Windows 上**仅支持** 
 2. 重启电脑。
 3. 重启后会自动启动 Ubuntu 终端，按提示设置 UNIX 用户名与密码。
 4. 检查 WSL 版本与发行版：
+
    ```powershell
    wsl -l -v
    ```
@@ -289,10 +291,10 @@ hermes setup        # 全量向导
 hermes model        # 仅交互式选择/配置 LLM
 ```
 
-向导询问 provider 时选 `custom (OpenAI-compatible)`，然后填写同一地区的一组值：
+向导询问 provider 时选 `custom (OpenAI-compatible)`，然后填写API配置：
 
-- 海外：Base URL `https://token.sensenova.ai/v1`，Model name `sensenova-6.8-flash-lite`
-- 中国内地：Base URL `https://token.sensenova.cn/v1`，Model name `sensenova-6.8-flash-lite`
+- Base URL：`https://token.sensenova.ai/v1`（海外版）；Base URL `https://token.sensenova.cn/v1`（中国内地）
+- Model name： `sensenova-6.8-flash-lite`
 - API Key：使用同一地区申请到的 key
 
 #### 2.B.4 验证 LLM 通路

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -5,8 +5,6 @@
 本文档引导你在 Windows / macOS / Linux 上安装 [OpenClaw](https://openclaw.ai/) 或 [hermes-agent](https://github.com/NousResearch/hermes-agent)，对接 SenseNova 大模型，并加载 `SenseNova-Skills` 中的技能，得到完整可用的 skill-driven agent。
 
 > 两个 agent 任选其一。OpenClaw 与 hermes-agent 均遵循 [Agent Skills](https://agentskills.io/) 规范，本仓库的 skill 在两边都能直接使用。
->
-> 本文同时列出海外版与中国内地版 SenseNova API 接入方式。请确保文档入口、API Key、Base URL 和模型名来自同一地区配置。
 
 ---
 
@@ -14,10 +12,10 @@
 
 后续两种 agent 都需要下面这组配置，但具体值取决于你使用的是海外版还是中国内地版：
 
-| 地区 | 文档 / 申请入口 | Base URL | 模型名 |
-| -------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| 海外 | 按照 [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs) 注册账号、验证邮箱，并在 Console → API Keys 创建 key | `https://token.sensenova.ai/v1` | `sensenova-6.8-flash-lite` |
-| 中国内地 | 在 [SenseNova 控制台 · token-plan](https://platform.sensenova.cn/token-plan) 免费申请并复制 API Key | `https://token.sensenova.cn/v1` | `sensenova-6.7-flash-lite` |
+| 地区     | 文档 / 申请入口                                                                                                           | Base URL                          | 模型名                       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------- |
+| 海外     | 按照[platform.sensenova.ai/docs](https://platform.sensenova.ai/docs) 注册账号、验证邮箱，并在 Console → API Keys 创建 key | `https://token.sensenova.ai/v1` | `sensenova-6.8-flash-lite` |
+| 中国内地 | 在[SenseNova 控制台 · token-plan](https://platform.sensenova.cn/token-plan) 免费申请并复制 API Key                        | `https://token.sensenova.cn/v1` | `sensenova-6.8-flash-lite` |
 
 > 端点是 OpenAI 兼容协议，可在任何"OpenAI compatible"配置位填写。
 
@@ -36,11 +34,11 @@
 
 预编译的安装器发布在 [GitHub Releases 页面](https://github.com/OpenSenseNova/agent_pack/releases/latest)：
 
-| 平台 | 下载 | 使用方式 |
-|------|------|---------|
-| Windows | [去最新 release 下载 `-windows-x64.exe`](https://github.com/OpenSenseNova/agent_pack/releases/latest) | 双击运行向导；安装过程在 WSL2 中执行，安装完成后当前 PowerShell 窗口会被接管，直接拉起 agent。 |
-| macOS | [去最新 release 下载 `-macos-universal.pkg`](https://github.com/OpenSenseNova/agent_pack/releases/latest) | 双击后按图形向导完成产品选择和 LLM 配置；安装完成后会按所选产品自动打开 OpenClaw Gateway Terminal 与 dashboard，并打开 Hermes Terminal。 |
-| Linux | [去最新 release 下载 `-linux.sh`](https://github.com/OpenSenseNova/agent_pack/releases/latest)，或使用右侧一行命令 | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`，或直接粘贴 `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` —— 两种方式都会在安装结束后用 `exec` 在当前 shell 里拉起 agent。 |
+| 平台    | 下载                                                                                                                | 使用方式                                                                                                                                                                                                                                             |
+| ------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows | [去最新 release 下载 `-windows-x64.exe`](https://github.com/OpenSenseNova/agent_pack/releases/latest)              | 双击运行向导；安装过程在 WSL2 中执行，安装完成后当前 PowerShell 窗口会被接管，直接拉起 agent。                                                                                                                                                       |
+| macOS   | [去最新 release 下载 `-macos-universal.pkg`](https://github.com/OpenSenseNova/agent_pack/releases/latest)          | 双击后按图形向导完成产品选择和 LLM 配置；安装完成后会按所选产品自动打开 OpenClaw Gateway Terminal 与 dashboard，并打开 Hermes Terminal。                                                                                                             |
+| Linux   | [去最新 release 下载 `-linux.sh`](https://github.com/OpenSenseNova/agent_pack/releases/latest)，或使用右侧一行命令 | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`，或直接粘贴 `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` —— 两种方式都会在安装结束后用 `exec` 在当前 shell 里拉起 agent。 |
 
 安装器询问 LLM 供应商时，选 **Custom (OpenAI-compatible)**，把 §0 里同一地区的一组值填进去（Base URL、API Key、模型名）。如果你处在国内网络，可以设置环境变量 `AGENTPACK_CN=1` 启用 GitHub 镜像回退。
 
@@ -62,6 +60,7 @@ OpenClaw 在 Windows 上推荐 WSL2，hermes-agent 在 Windows 上**仅支持** 
    ```powershell
    wsl --install
    ```
+
    该命令会启用所需的 Windows 功能并安装默认的 Ubuntu 发行版。
 2. 重启电脑。
 3. 重启后会自动启动 Ubuntu 终端，按提示设置 UNIX 用户名与密码。
@@ -69,6 +68,7 @@ OpenClaw 在 Windows 上推荐 WSL2，hermes-agent 在 Windows 上**仅支持** 
    ```powershell
    wsl -l -v
    ```
+
    `VERSION` 一列应为 `2`。
 
 之后所有命令都在 **Ubuntu (WSL2) 终端**里执行，而不是 PowerShell。
@@ -111,7 +111,7 @@ OpenClaw 需要 **Node.js 24（推荐）或 22.14+**。
 
 任选其一：
 
-- **官方安装包**：从 <https://nodejs.org/> 下载 LTS。
+- **官方安装包**：从 [https://nodejs.org/](https://nodejs.org/) 下载 LTS。
 - **Homebrew（macOS）**：`brew install node@24`
 - **nvm（推荐 Linux/WSL2/macOS）**：
   ```bash
@@ -177,7 +177,7 @@ openclaw onboard --install-daemon
 │  OpenAI-compatible
 │
 ◇  Model ID
-│  sensenova-6.7-flash-lite
+│  sensenova-6.8-flash-lite
 │
 ◇  Verification successful.
 │
@@ -205,7 +205,7 @@ openclaw onboard --install-daemon
 两套 SenseNova 配置请成对使用：
 
 - 海外：`https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`
-- 中国内地：`https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`
+- 中国内地：`https://token.sensenova.cn/v1` + `sensenova-6.8-flash-lite`
 
 #### 2.A.5 验证 LLM 通路
 
@@ -273,8 +273,8 @@ hermes config set model.default custom/sensenova-6.8-flash-lite
 hermes config set model.provider custom
 hermes config set model.base_url https://token.sensenova.cn/v1
 hermes config set model.api_key "<你的 API Key>"
-hermes config set model.name sensenova-6.7-flash-lite
-hermes config set model.default custom/sensenova-6.7-flash-lite
+hermes config set model.name sensenova-6.8-flash-lite
+hermes config set model.default custom/sensenova-6.8-flash-lite
 ```
 
 > 最后一行是必填项 —— 不设置 `model.default` 时，hermes 仍会沿用安装时的默认模型（如 `anthropic/claude-opus-4.6`），运行 `hermes -z "..."` 会报 `HTTP 404: model is not found`。如果不想一条条敲，也可以改用下面的 `hermes setup` / `hermes model` 向导，两者都会顺带帮你设好 `model.default`。
@@ -292,7 +292,7 @@ hermes model        # 仅交互式选择/配置 LLM
 向导询问 provider 时选 `custom (OpenAI-compatible)`，然后填写同一地区的一组值：
 
 - 海外：Base URL `https://token.sensenova.ai/v1`，Model name `sensenova-6.8-flash-lite`
-- 中国内地：Base URL `https://token.sensenova.cn/v1`，Model name `sensenova-6.7-flash-lite`
+- 中国内地：Base URL `https://token.sensenova.cn/v1`，Model name `sensenova-6.8-flash-lite`
 - API Key：使用同一地区申请到的 key
 
 #### 2.B.4 验证 LLM 通路
@@ -331,9 +331,11 @@ cp -r skills/* ~/.hermes/skills/
 ```
 
 > 想保持与仓库同步可以用软链接代替 `cp -r`，例如：
+>
 > ```bash
 > ln -s "$PWD"/skills/* ~/.openclaw/skills/
 > ```
+>
 > 之后 `git pull` 就能自动获得 skill 更新。
 
 ### 3.3 安装方式二：直接交给 agent 安装
@@ -373,5 +375,5 @@ cp -r skills/* ~/.hermes/skills/
 - **Node 版本太低**：`node -v` 必须 ≥ 22.14。用 nvm 切换：`nvm install 24 && nvm use 24`。
 - **`openclaw doctor` / `hermes doctor` 报错**：按报告中的提示逐项修复，缺什么装什么。
 - **LLM 调用 401 / 403**：检查配置中的 LLM API Key（OpenClaw 用 `openclaw config get models.providers.custom`，hermes-agent 用 `hermes config get model.api_key`）；并确认 API Key、Base URL、模型名来自同一地区配置。
-- **Provider 校验失败**：优先检查是否把两套配置混用了。请成对使用：海外 `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`，或中国内地 `https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`。
+- **Provider 校验失败**：优先检查是否把两套配置混用了。请成对使用：海外 `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`，或中国内地 `https://token.sensenova.cn/v1` + `sensenova-6.8-flash-lite`。
 - **WSL2 中 `curl` 慢/卡**：确认 WSL2 网络模式（`wsl --status`），必要时切到 `mirrored` 网络模式或使用代理。

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -2,21 +2,22 @@
 
 简体中文 | [English](INSTALL.md)
 
-本文档引导你在 Windows / macOS / Linux 上安装 [OpenClaw](https://openclaw.ai/) 或 [hermes-agent](https://github.com/NousResearch/hermes-agent)，对接 [SenseNova](https://platform.sensenova.cn/) 大模型，并加载 `SenseNova-Skills` 中的技能，得到完整可用的 skill-driven agent。
+本文档引导你在 Windows / macOS / Linux 上安装 [OpenClaw](https://openclaw.ai/) 或 [hermes-agent](https://github.com/NousResearch/hermes-agent)，对接 SenseNova 大模型，并加载 `SenseNova-Skills` 中的技能，得到完整可用的 skill-driven agent。
 
 > 两个 agent 任选其一。OpenClaw 与 hermes-agent 均遵循 [Agent Skills](https://agentskills.io/) 规范，本仓库的 skill 在两边都能直接使用。
+>
+> 本文同时列出海外版与中国内地版 SenseNova API 接入方式。请确保文档入口、API Key、Base URL 和模型名来自同一地区配置。
 
 ---
 
 ## 0. 先准备 SenseNova API Key 与端点
 
-后续两种 agent 都会用到下面这组配置：
+后续两种 agent 都需要下面这组配置，但具体值取决于你使用的是海外版还是中国内地版：
 
-| 字段       | 值                                                                                                |
-| -------- | ------------------------------------------------------------------------------------------------ |
-| Base URL | `https://token.sensenova.cn/v1`                                                                  |
-| API Key  | 在 [SenseNova 控制台 · token-plan](https://platform.sensenova.cn/token-plan) 免费申请并复制。 |
-| 模型名      | `sensenova-6.7-flash-lite`                                                                       |
+| 地区 | 文档 / 申请入口 | Base URL | 模型名 |
+| -------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| 海外 | 按照 [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs) 注册账号、验证邮箱，并在 Console → API Keys 创建 key | `https://token.sensenova.ai/v1` | `sensenova-6.8-flash-lite` |
+| 中国内地 | 在 [SenseNova 控制台 · token-plan](https://platform.sensenova.cn/token-plan) 免费申请并复制 API Key | `https://token.sensenova.cn/v1` | `sensenova-6.7-flash-lite` |
 
 > 端点是 OpenAI 兼容协议，可在任何"OpenAI compatible"配置位填写。
 
@@ -41,7 +42,7 @@
 | macOS | [去最新 release 下载 `-macos-universal.pkg`](https://github.com/OpenSenseNova/agent_pack/releases/latest) | 双击后按图形向导完成产品选择和 LLM 配置；安装完成后会按所选产品自动打开 OpenClaw Gateway Terminal 与 dashboard，并打开 Hermes Terminal。 |
 | Linux | [去最新 release 下载 `-linux.sh`](https://github.com/OpenSenseNova/agent_pack/releases/latest)，或使用右侧一行命令 | `chmod +x AgentPack-*-linux.sh && ./AgentPack-*-linux.sh`，或直接粘贴 `bash <(curl -fsSL https://raw.githubusercontent.com/OpenSenseNova/agent_pack/main/linux/install.sh)` —— 两种方式都会在安装结束后用 `exec` 在当前 shell 里拉起 agent。 |
 
-安装器询问 LLM 供应商时，选 **Custom (OpenAI-compatible)**，把 §0 里的三个值填进去（Base URL、API Key、模型名）。如果你处在国内网络，可以设置环境变量 `AGENTPACK_CN=1` 启用 GitHub 镜像回退。
+安装器询问 LLM 供应商时，选 **Custom (OpenAI-compatible)**，把 §0 里同一地区的一组值填进去（Base URL、API Key、模型名）。如果你处在国内网络，可以设置环境变量 `AGENTPACK_CN=1` 启用 GitHub 镜像回退。
 
 > **Skills 已内置** —— Agent Pack 直接把 SenseNova-Skills 提交在各产品的 `skills/` 目录中，并随产品一起安装。**走这条路线无需再执行 §3（"加载本仓库的 Skill"）** —— 技能已经加载完毕。
 
@@ -201,6 +202,11 @@ openclaw onboard --install-daemon
 │  Skip for now
 ```
 
+两套 SenseNova 配置请成对使用：
+
+- 海外：`https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`
+- 中国内地：`https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`
+
 #### 2.A.5 验证 LLM 通路
 
 ```bash
@@ -249,7 +255,19 @@ hermes doctor
 
 #### 2.B.3 配置 SenseNova LLM
 
-最快方式 — 用 `hermes config set`：
+最快方式 — 用 `hermes config set`。
+
+海外：
+
+```bash
+hermes config set model.provider custom
+hermes config set model.base_url https://token.sensenova.ai/v1
+hermes config set model.api_key "<你的 API Key>"
+hermes config set model.name sensenova-6.8-flash-lite
+hermes config set model.default custom/sensenova-6.8-flash-lite
+```
+
+中国内地：
 
 ```bash
 hermes config set model.provider custom
@@ -271,11 +289,11 @@ hermes setup        # 全量向导
 hermes model        # 仅交互式选择/配置 LLM
 ```
 
-向导询问 provider 时选 `custom (OpenAI-compatible)`，然后依次填入：
+向导询问 provider 时选 `custom (OpenAI-compatible)`，然后填写同一地区的一组值：
 
-- Base URL：`https://token.sensenova.cn/v1`
-- API Key：上面申请到的 key
-- Model name：`sensenova-6.7-flash-lite`
+- 海外：Base URL `https://token.sensenova.ai/v1`，Model name `sensenova-6.8-flash-lite`
+- 中国内地：Base URL `https://token.sensenova.cn/v1`，Model name `sensenova-6.7-flash-lite`
+- API Key：使用同一地区申请到的 key
 
 #### 2.B.4 验证 LLM 通路
 
@@ -354,5 +372,6 @@ cp -r skills/* ~/.hermes/skills/
 - **`wsl --install` 提示找不到命令**：需要 Windows 10 22H2+ / Windows 11，并以管理员身份打开 PowerShell。
 - **Node 版本太低**：`node -v` 必须 ≥ 22.14。用 nvm 切换：`nvm install 24 && nvm use 24`。
 - **`openclaw doctor` / `hermes doctor` 报错**：按报告中的提示逐项修复，缺什么装什么。
-- **LLM 调用 401 / 403**：检查配置中的 LLM API Key（OpenClaw 用 `openclaw config get models.providers.custom`，hermes-agent 用 `hermes config get model.api_key`）；确认 [token-plan](https://platform.sensenova.cn/token-plan) 中 key 仍在有效额度内。
+- **LLM 调用 401 / 403**：检查配置中的 LLM API Key（OpenClaw 用 `openclaw config get models.providers.custom`，hermes-agent 用 `hermes config get model.api_key`）；并确认 API Key、Base URL、模型名来自同一地区配置。
+- **Provider 校验失败**：优先检查是否把两套配置混用了。请成对使用：海外 `https://token.sensenova.ai/v1` + `sensenova-6.8-flash-lite`，或中国内地 `https://token.sensenova.cn/v1` + `sensenova-6.7-flash-lite`。
 - **WSL2 中 `curl` 慢/卡**：确认 WSL2 网络模式（`wsl --status`），必要时切到 `mirrored` 网络模式或使用代理。

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Raccoon now ships a full upgrade across product capability and client experience
 These skills are designed to run inside an [Agent Skills](https://agentskills.io/)-compatible agent.
 
 - **Recommended runtime**: pair them with **[OpenClaw](https://openclaw.ai/)** or **[hermes-agent](https://github.com/NousResearch/hermes-agent)**.
-- **Recommended LLM**: pair them with the **[SenseNova international API docs](https://platform.sensenova.ai/docs)** and use the global endpoint `https://token.sensenova.ai/v1`.
+- **Recommended LLM**: pair them with the **SenseNova Platform API**.
+  International: [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs), Base URL `https://token.sensenova.ai/v1`
+  Mainland China: [platform.sensenova.cn/token-plan](https://platform.sensenova.cn/token-plan), Base URL `https://token.sensenova.cn/v1`
 - **Install & configure**: follow the full walkthrough in **[`INSTALL.md`](INSTALL.md)**.
 
-> The English docs in this repo target the international SenseNova API. The Chinese docs keep the mainland China token-plan flow.
+> This repo documents both the international and mainland China SenseNova API flows. Make sure the docs page, API key, base URL, and model name all come from the same region.
 
 **Recommended: let the agent install the skills for you.** Hand it the repo URL and ask it to clone and drop the skills into the right directory — for example:
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 </p>
 
 <p align="center">
-  <a href="https://platform.sensenova.cn"><img src="https://img.shields.io/badge/Website-Platform-1f6feb?style=flat-square&logo=googlechrome&logoColor=white" alt="Website"></a>
+  <a href="https://sensenova.ai"><img src="https://img.shields.io/badge/Website-Platform-1f6feb?style=flat-square&logo=googlechrome&logoColor=white" alt="Website"></a>
   <a href="https://office.xiaohuanxiong.com/home"><img src="https://img.shields.io/badge/%F0%9F%A6%9D_Raccoon-Try%20it%20free-f29415?style=flat-square" alt="Raccoon"></a>
-  <a href="https://platform.sensenova.cn/token-plan"><img src="https://img.shields.io/badge/Token_Plan-Free-2ea44f?style=flat-square&logo=opensea&logoColor=white" alt="Token Plan"></a>
+  <a href="https://platform.sensenova.ai/docs"><img src="https://img.shields.io/badge/API_Docs-Global-2ea44f?style=flat-square&logo=readthedocs&logoColor=white" alt="API Docs"></a>
   <a href="https://github.com/OpenSenseNova/SenseNova-U1"><img src="https://img.shields.io/badge/SenseNova-U1-8957e5?style=flat-square&logo=github&logoColor=white" alt="SenseNova U1"></a>
   <a href="https://github.com/OpenSenseNova/SenseNova6.7"><img src="https://img.shields.io/badge/SenseNova-6.7-cf222e?style=flat-square&logo=github&logoColor=white" alt="SenseNova 6.7"></a>
 </p>
@@ -40,8 +40,10 @@ Raccoon now ships a full upgrade across product capability and client experience
 These skills are designed to run inside an [Agent Skills](https://agentskills.io/)-compatible agent.
 
 - **Recommended runtime**: pair them with **[OpenClaw](https://openclaw.ai/)** or **[hermes-agent](https://github.com/NousResearch/hermes-agent)**.
-- **Recommended LLM**: pair them with the **[SenseNova Platform API](https://platform.sensenova.cn/token-plan)** — a free token plan is available.
+- **Recommended LLM**: pair them with the **[SenseNova international API docs](https://platform.sensenova.ai/docs)** and use the global endpoint `https://token.sensenova.ai/v1`.
 - **Install & configure**: follow the full walkthrough in **[`INSTALL.md`](INSTALL.md)**.
+
+> The English docs in this repo target the international SenseNova API. The Chinese docs keep the mainland China token-plan flow.
 
 **Recommended: let the agent install the skills for you.** Hand it the repo URL and ask it to clone and drop the skills into the right directory — for example:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,7 +41,7 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 本仓库的 skill 需要配合支持 [Agent Skills](https://agentskills.io/) 规范的智能体使用。
 
 - **推荐运行时**：**[OpenClaw](https://openclaw.ai/)** 或 **[hermes-agent](https://github.com/NousResearch/hermes-agent)**。
-- **推荐 LLM**：配合使用 **[SenseNova 平台 API](https://platform.sensenova.cn/token-plan)**（提供免费 token 套餐）。
+- **推荐 LLM**：配合使用 **[SenseNova 平台 API](https://platform.sensenova.cn/token-plan)**（为中国用户提供免费 token 套餐；非中国用户请参考英文版 README.md）。
 - **安装与配置**：完整流程请参考 **[`INSTALL_CN.md`](INSTALL_CN.md)**。
 
 **推荐做法：直接让 agent 帮你装好这些 skill。** 把仓库地址交给它，让它自己克隆并把内容拷贝到目标目录，例如：

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,7 +41,9 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 本仓库的 skill 需要配合支持 [Agent Skills](https://agentskills.io/) 规范的智能体使用。
 
 - **推荐运行时**：**[OpenClaw](https://openclaw.ai/)** 或 **[hermes-agent](https://github.com/NousResearch/hermes-agent)**。
-- **推荐 LLM**：配合使用 **[SenseNova 平台 API](https://platform.sensenova.cn/token-plan)**（为中国用户提供免费 token 套餐；非中国用户请参考英文版 README.md）。
+- **推荐 LLM**：配合使用 **SenseNova 平台 API**。
+  中国内地：[`platform.sensenova.cn/token-plan`](https://platform.sensenova.cn/token-plan)，Base URL `https://token.sensenova.cn/v1`（为中国用户提供免费 token 套餐）
+  海外：请参考英文版 [`README.md`](README.md) 或 [`platform.sensenova.ai/docs`](https://platform.sensenova.ai/docs)，Base URL `https://token.sensenova.ai/v1`
 - **安装与配置**：完整流程请参考 **[`INSTALL_CN.md`](INSTALL_CN.md)**。
 
 **推荐做法：直接让 agent 帮你装好这些 skill。** 把仓库地址交给它，让它自己克隆并把内容拷贝到目标目录，例如：

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,34 +67,40 @@ When `max_rounds=1`, VLM review is skipped. Setting `max_rounds` to `2` or highe
 
 Image generation quality issues (garbled text/typos, unappealing layout, incorrect human anatomy, etc.) require waiting for the new model release, which will focus on improving image generation quality.
 
+## Q: Which SenseNova API should international users use?
+
+If you are following the English docs in this repo, use the official international SenseNova API docs at [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs) and set your OpenAI-compatible base URL to:
+
+```text
+https://token.sensenova.ai/v1
+```
+
+Do not reuse the mainland China `.cn` endpoint from older screenshots or Chinese-only setup guides when configuring the English flow.
+
 ## Q: How do I deal with reasoning/coding ability and stability issues?
 
 SenseNova 6.7 Flash-Lite has a relatively small parameter count, so its ability is limited on complex reasoning, large-scale coding tasks, and long-context scenarios — you may see degraded quality, infinite loops, repeated output, or the model cutting corners on tasks. Try switching to `deepseek-v4-pro`, which is more stable in these scenarios.
 
 ## Q: How do I deal with rate limiting and quota issues?
 
-The SenseNova Token Plan is currently in a free trial phase. Limited by the free quota and overall load, you may see the following during peak hours:
+The official international docs currently list a request quota of 1,500 requests per 5 hours for both `sensenova-6.8-flash-lite` and `sensenova-u1-fast`. Around the limit or during peak hours, you may see:
 
-- **429 rate limiting:** the free quota is 1,500 calls / 5 hours (sliding window); once exceeded you are throttled automatically and recover after 5 hours.
-- **FREE_QUOTA_EXHAUSTED:** once the free quota is used up, the endpoint becomes temporarily inactive and recovers after the window resets.
+- **429 rate limiting:** once the quota window is exceeded you are throttled automatically and recover after 5 hours.
+- **FREE_QUOTA_EXHAUSTED:** once the current quota window is used up, the endpoint becomes temporarily inactive and recovers after the window resets.
 - **High latency / no response:** queuing may occur when concurrency is high during peak hours.
-
-**What's coming:** a paid Token Plan is in preparation and, once live, will offer higher concurrency quotas, larger call volumes, and more stable service quality.
-
-## Q: When will the paid Token Plan be available?
-
-The paid Token Plan is in preparation and is expected to launch later. Please watch the official announcements for the exact timing.
 
 ## Q: What if the Anthropic format isn't supported?
 
-SenseNova supports both the Anthropic Messages format (via `https://token.sensenova.cn`) and the OpenAI-compatible format (via `https://token.sensenova.cn/v1`). Claude Code can connect using the Anthropic format directly, with no protocol conversion required. For the exact configuration, see the Provider configuration section of the [SenseNova-Skills Agent access tutorial](https://sensetime.feishu.cn/wiki/LYuWwvwABiRtvgkce6DcwCw8nec).
+For the international API, SenseNova supports both the Anthropic Messages format (via `https://token.sensenova.ai`) and the OpenAI-compatible format (via `https://token.sensenova.ai/v1`). Claude Code can connect using the Anthropic format directly, with no protocol conversion required.
 
 ## Q: What if the model name isn't recognized?
 
-If you hit an error like `The supported API model names are ... but you passed ...`, first confirm the model name is spelled correctly. The currently supported model names are:
+If you hit an error like `The supported API model names are ... but you passed ...`, first confirm the model name is spelled correctly. The current international docs list:
 
-- `sensenova-6.7-flash-lite` — SenseNova 6.7 Flash-Lite, lightweight and fast
+- `sensenova-6.8-flash-lite` — SenseNova 6.8 Flash Lite, lightweight multimodal chat model
 - `sensenova-u1-fast` — SenseNova U1 Fast, reasoning-enhanced
+
+As of August 12, 2026, the official international docs also state that calls made with `sensenova-6.7-flash-lite` are compatibility-routed to `sensenova-6.8-flash-lite` through August 31, 2026.
 
 Note: model names are case-sensitive, so make sure they match the names above exactly.
 
@@ -107,11 +113,13 @@ Note: model names are case-sensitive, so make sure they match the names above ex
 A 401 means the API key is invalid or not set correctly. Please check:
 
 - The API key was copied correctly (no extra spaces or line breaks)
-- You have obtained a valid key from the [SenseNova platform](https://www.sensenova.cn/token-plan)
+- You created the key through the international flow described in [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs)
+- Your account completed the email verification step required before creating API keys
+- Your client is using the correct international base URL: `https://token.sensenova.ai/v1`
 - The Authorization header is in the format `Bearer sk-xxx`
 
 If you've confirmed the key is correct but still get a 401, regenerate the key and try again.
 
 ---
 
-> **Provider configuration reference:** For how to configure providers for SenseNova models (cc-switch, Claude Code, Codex, etc.), see the [SenseNova-Skills Agent access tutorial](https://sensetime.feishu.cn/wiki/LYuWwvwABiRtvgkce6DcwCw8nec).
+> **Provider configuration reference:** For the latest international provider examples, see [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,40 +67,34 @@ When `max_rounds=1`, VLM review is skipped. Setting `max_rounds` to `2` or highe
 
 Image generation quality issues (garbled text/typos, unappealing layout, incorrect human anatomy, etc.) require waiting for the new model release, which will focus on improving image generation quality.
 
-## Q: Which SenseNova API should international users use?
-
-If you are following the English docs in this repo, use the official international SenseNova API docs at [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs) and set your OpenAI-compatible base URL to:
-
-```text
-https://token.sensenova.ai/v1
-```
-
-Do not reuse the mainland China `.cn` endpoint from older screenshots or Chinese-only setup guides when configuring the English flow.
-
 ## Q: How do I deal with reasoning/coding ability and stability issues?
 
 SenseNova 6.7 Flash-Lite has a relatively small parameter count, so its ability is limited on complex reasoning, large-scale coding tasks, and long-context scenarios — you may see degraded quality, infinite loops, repeated output, or the model cutting corners on tasks. Try switching to `deepseek-v4-pro`, which is more stable in these scenarios.
 
 ## Q: How do I deal with rate limiting and quota issues?
 
-The official international docs currently list a request quota of 1,500 requests per 5 hours for both `sensenova-6.8-flash-lite` and `sensenova-u1-fast`. Around the limit or during peak hours, you may see:
+The SenseNova Token Plan is currently in a free trial phase. Limited by the free quota and overall load, you may see the following during peak hours:
 
-- **429 rate limiting:** once the quota window is exceeded you are throttled automatically and recover after 5 hours.
-- **FREE_QUOTA_EXHAUSTED:** once the current quota window is used up, the endpoint becomes temporarily inactive and recovers after the window resets.
+- **429 rate limiting:** the free quota is 1,500 calls / 5 hours (sliding window); once exceeded you are throttled automatically and recover after 5 hours.
+- **FREE_QUOTA_EXHAUSTED:** once the free quota is used up, the endpoint becomes temporarily inactive and recovers after the window resets.
 - **High latency / no response:** queuing may occur when concurrency is high during peak hours.
+
+**What's coming:** a paid Token Plan is in preparation and, once live, will offer higher concurrency quotas, larger call volumes, and more stable service quality.
+
+## Q: When will the paid Token Plan be available?
+
+The paid Token Plan is in preparation and is expected to launch later. Please watch the official announcements for the exact timing.
 
 ## Q: What if the Anthropic format isn't supported?
 
-For the international API, SenseNova supports both the Anthropic Messages format (via `https://token.sensenova.ai`) and the OpenAI-compatible format (via `https://token.sensenova.ai/v1`). Claude Code can connect using the Anthropic format directly, with no protocol conversion required.
+SenseNova supports both the Anthropic Messages format (via `https://token.sensenova.cn`) and the OpenAI-compatible format (via `https://token.sensenova.cn/v1`). Claude Code can connect using the Anthropic format directly, with no protocol conversion required. For the exact configuration, see the Provider configuration section of the [SenseNova-Skills Agent access tutorial](https://sensetime.feishu.cn/wiki/LYuWwvwABiRtvgkce6DcwCw8nec).
 
 ## Q: What if the model name isn't recognized?
 
-If you hit an error like `The supported API model names are ... but you passed ...`, first confirm the model name is spelled correctly. The current international docs list:
+If you hit an error like `The supported API model names are ... but you passed ...`, first confirm the model name is spelled correctly. The currently supported model names are:
 
-- `sensenova-6.8-flash-lite` — SenseNova 6.8 Flash Lite, lightweight multimodal chat model
+- `sensenova-6.7-flash-lite` — SenseNova 6.7 Flash-Lite, lightweight and fast
 - `sensenova-u1-fast` — SenseNova U1 Fast, reasoning-enhanced
-
-As of August 12, 2026, the official international docs also state that calls made with `sensenova-6.7-flash-lite` are compatibility-routed to `sensenova-6.8-flash-lite` through August 31, 2026.
 
 Note: model names are case-sensitive, so make sure they match the names above exactly.
 
@@ -113,13 +107,11 @@ Note: model names are case-sensitive, so make sure they match the names above ex
 A 401 means the API key is invalid or not set correctly. Please check:
 
 - The API key was copied correctly (no extra spaces or line breaks)
-- You created the key through the international flow described in [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs)
-- Your account completed the email verification step required before creating API keys
-- Your client is using the correct international base URL: `https://token.sensenova.ai/v1`
+- You have obtained a valid key from the [SenseNova platform](https://www.sensenova.cn/token-plan)
 - The Authorization header is in the format `Bearer sk-xxx`
 
 If you've confirmed the key is correct but still get a 401, regenerate the key and try again.
 
 ---
 
-> **Provider configuration reference:** For the latest international provider examples, see [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs).
+> **Provider configuration reference:** For how to configure providers for SenseNova models (cc-switch, Claude Code, Codex, etc.), see the [SenseNova-Skills Agent access tutorial](https://sensetime.feishu.cn/wiki/LYuWwvwABiRtvgkce6DcwCw8nec).

--- a/docs/sn-image-generate.md
+++ b/docs/sn-image-generate.md
@@ -96,15 +96,29 @@ pip install -r skills/sn-image-base/requirements.txt
 
 **最小化配置：**
 
-推荐使用 [SenseNova Token Plan](https://platform.sensenova.cn/token-plan) 来配置这些技能。
+这些技能同时支持海外版与中国内地版 SenseNova API。
 
-前往 <https://platform.sensenova.cn/token-plan/> 注册免费账号并获取 API Key。
+- 海外：参考 <https://platform.sensenova.ai/docs> 注册账号、验证邮箱，并在 Console → API Keys 创建 key
+- 中国内地：前往 <https://platform.sensenova.cn/token-plan/> 注册免费账号并获取 API Key
+
+请确保文档入口、API Key、Base URL 与模型名来自同一地区配置。
 
 将以下环境变量写入 `~/.openclaw/.env`（OpenClaw）或 `~/.hermes/.env`（Hermes）：
+
+海外：
+
+```ini
+SN_BASE_URL="https://token.sensenova.ai/v1"
+SN_API_KEY="your-api-key"
+SN_CHAT_MODEL="sensenova-6.8-flash-lite"
+```
+
+中国内地：
 
 ```ini
 SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_API_KEY="your-api-key"
+SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ```
 
 环境变量 fallback 优先级为：专用变量 > 领域共享变量 > 全局变量。若某个能力需要不同 provider，可再设置 `SN_TEXT_*`、`SN_VISION_*`、`SN_CHAT_*` 或 `SN_IMAGE_GEN_*`。

--- a/docs/sn-image-generate.md
+++ b/docs/sn-image-generate.md
@@ -118,7 +118,7 @@ SN_CHAT_MODEL="sensenova-6.8-flash-lite"
 ```ini
 SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_API_KEY="your-api-key"
-SN_CHAT_MODEL="sensenova-6.7-flash-lite"
+SN_CHAT_MODEL="sensenova-6.8-flash-lite"
 ```
 
 环境变量 fallback 优先级为：专用变量 > 领域共享变量 > 全局变量。若某个能力需要不同 provider，可再设置 `SN_TEXT_*`、`SN_VISION_*`、`SN_CHAT_*` 或 `SN_IMAGE_GEN_*`。

--- a/docs/sn-image-generate_en.md
+++ b/docs/sn-image-generate_en.md
@@ -118,7 +118,7 @@ Mainland China:
 ```ini
 SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_API_KEY="your-api-key"
-SN_CHAT_MODEL="sensenova-6.7-flash-lite"
+SN_CHAT_MODEL="sensenova-6.8-flash-lite"
 ```
 
 Fallback priority is dedicated variable > domain shared variable > global variable. If a capability needs a different provider, set `SN_TEXT_*`, `SN_VISION_*`, `SN_CHAT_*`, or `SN_IMAGE_GEN_*`.

--- a/docs/sn-image-generate_en.md
+++ b/docs/sn-image-generate_en.md
@@ -96,15 +96,16 @@ pip install -r skills/sn-image-base/requirements.txt
 
 **Minimum Configurations:**
 
-We recommend you to try out our [SenseNova Token Plan](https://platform.sensenova.cn/token-plan) to setup these skills.
+For the English/international flow, use the official [SenseNova API docs](https://platform.sensenova.ai/docs).
 
-Go to <https://platform.sensenova.cn/token-plan/> to register a free account and get your API key.
+Create an account, verify your email, then create an API key in Console → API Keys.
 
 Set the following environment variables in `~/.openclaw/.env` (for OpenClaw) or `~/.hermes/.env` (for Hermes):
 
 ```ini
-SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_BASE_URL="https://token.sensenova.ai/v1"
 SN_API_KEY="your-api-key"
+SN_CHAT_MODEL="sensenova-6.8-flash-lite"
 ```
 
 Fallback priority is dedicated variable > domain shared variable > global variable. If a capability needs a different provider, set `SN_TEXT_*`, `SN_VISION_*`, `SN_CHAT_*`, or `SN_IMAGE_GEN_*`.

--- a/docs/sn-image-generate_en.md
+++ b/docs/sn-image-generate_en.md
@@ -96,16 +96,29 @@ pip install -r skills/sn-image-base/requirements.txt
 
 **Minimum Configurations:**
 
-For the English/international flow, use the official [SenseNova API docs](https://platform.sensenova.ai/docs).
+Use one of the following SenseNova API flows:
 
-Create an account, verify your email, then create an API key in Console → API Keys.
+- International: [platform.sensenova.ai/docs](https://platform.sensenova.ai/docs)
+- Mainland China: [platform.sensenova.cn/token-plan](https://platform.sensenova.cn/token-plan)
+
+Make sure the docs page, API key, base URL, and model all come from the same region.
 
 Set the following environment variables in `~/.openclaw/.env` (for OpenClaw) or `~/.hermes/.env` (for Hermes):
+
+International:
 
 ```ini
 SN_BASE_URL="https://token.sensenova.ai/v1"
 SN_API_KEY="your-api-key"
 SN_CHAT_MODEL="sensenova-6.8-flash-lite"
+```
+
+Mainland China:
+
+```ini
+SN_BASE_URL="https://token.sensenova.cn/v1"
+SN_API_KEY="your-api-key"
+SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ```
 
 Fallback priority is dedicated variable > domain shared variable > global variable. If a capability needs a different provider, set `SN_TEXT_*`, `SN_VISION_*`, `SN_CHAT_*`, or `SN_IMAGE_GEN_*`.


### PR DESCRIPTION
## 背景

本 PR 主要修正仓库英文文档中面向海外用户的 SenseNova API 接入说明，避免继续误导用户使用中国区 `.cn` 的 token-plan 接法。

## 修改内容

- 将英文文档中的 SenseNova 接入文档入口统一调整为：
  - `https://platform.sensenova.ai/docs`
- 将英文文档中的 OpenAI-compatible Base URL 统一调整为：
  - `https://token.sensenova.ai/v1`
- 将英文文档中的示例模型调整为：
  - `sensenova-6.8-flash-lite`
- 在 `README_CN.md` 中补充说明：
  - 中国用户可使用免费 token 套餐
  - 非中国用户请参考英文版 `README.md`

## 涉及文件

- `README.md`
- `INSTALL.md`
- `docs/sn-image-generate_en.md`
- `README_CN.md`

## 说明

- `docs/faq.md` 本次未改动
- 中文安装/接入文档本次未调整，仍保持原有中国区说明