### PR TITLE
docs: add third-party quick-try section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Raccoon now ships a full upgrade across product capability and client experience
 
 > 👉 Try it: [xiaohuanxiong.com](https://office.xiaohuanxiong.com/home)
 
+## Third-Party Quick Try
+
+If you want to try a single skill before setting up the full local stack, here are some community / third-party entry points.
+
+> These links are maintained outside this repository and are not part of the official SenseNova-Skills support surface. Availability, account requirements, and platform terms may vary by provider.
+
+- [`sn-infographic` on ClawMama (Telegram / WhatsApp)](https://app.clawmama.run/skills/3k6s9d/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_opensensenova_sensenova_skills_sn_infographic) — a lightweight first run for the infographic workflow in an OpenClaw / Hermes-style agent.
+
 ## How to Use
 
 These skills are designed to run inside an [Agent Skills](https://agentskills.io/)-compatible agent.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ Raccoon now ships a full upgrade across product capability and client experience
 
 > 👉 Try it: [xiaohuanxiong.com](https://office.xiaohuanxiong.com/home)
 
-## Third-Party Quick Try
-
-If you want to try a single skill before setting up the full local stack, here are some community / third-party entry points.
-
-> These links are maintained outside this repository and are not part of the official SenseNova-Skills support surface. Availability, account requirements, and platform terms may vary by provider.
-
-- [`sn-infographic` on ClawMama (Telegram / WhatsApp)](https://app.clawmama.run/skills/3k6s9d/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_opensensenova_sensenova_skills_sn_infographic) — a lightweight first run for the infographic workflow in an OpenClaw / Hermes-style agent.
-
 ## How to Use
 
 These skills are designed to run inside an [Agent Skills](https://agentskills.io/)-compatible agent.
@@ -182,6 +174,14 @@ A few `sn-infographic` outputs (more in [`docs/sn-infographic-examples.md`](docs
 [`examples/property-fee-pricing-ppt`](examples/property-fee-pricing-ppt/). The agent takes a free-form brief — topic (property fee pricing), audience (property staff + committee), 26 pages, black-and-white warm style — and first commits to an outline plus a per-page asset plan that conforms to the style spec. Each slide is then built as semantic per-page HTML rather than free-form image generation: copy, layout, illustrations, icons, and any data charts are reasoned about per slot. Imagery is produced or selected per slot and VLM-checked against the page's intent; each rendered page goes through a review pass with optional rewrite for coherence and copy quality. Final pages are screenshotted and composited into the PPTX, with the per-page HTML kept alongside for direct browser preview or re-editing. The example demonstrates `sn-ppt-standard` style consistency on a long, prose-heavy deck where every slide must obey the same audience and palette constraints.
 
 - Depends on: [`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md), [`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)
+
+## Third-Party Quick Try
+
+If you want to try a single skill before setting up the full local stack, here are some community / third-party entry points.
+
+> These links are maintained outside this repository and are not part of the official SenseNova-Skills support surface. Availability, account requirements, and platform terms may vary by provider.
+
+- [`sn-infographic` on ClawMama (Telegram / WhatsApp)](https://app.clawmama.run/skills/3k6s9d/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_opensensenova_sensenova_skills_sn_infographic) — a lightweight first run for the infographic workflow in an OpenClaw / Hermes-style agent.
 
 ## FAQ
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -36,14 +36,6 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 
 > 👉 立即体验：[xiaohuanxiong.com](https://office.xiaohuanxiong.com/home)
 
-## 社区与第三方体验入口
-
-如果你想先快速体验单个 skill、再决定是否搭建完整本地环境，也可以先试试下面这些社区 / 第三方入口。
-
-> 这些链接并非由本仓库官方维护，不属于 SenseNova-Skills 的官方支持范围。具体可用性、账号要求与平台条款请以对应提供方为准。
-
-- [`sn-infographic`（ClawMama / Telegram / WhatsApp）](https://app.clawmama.run/skills/3k6s9d/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_opensensenova_sensenova_skills_sn_infographic) — 适合先低门槛体验一次信息图生成工作流。
-
 ## 如何使用
 
 本仓库的 skill 需要配合支持 [Agent Skills](https://agentskills.io/) 规范的智能体使用。
@@ -181,6 +173,14 @@ Hermes 把目录换成 `~/.hermes/skills/` 即可。
 [`examples/property-fee-pricing-ppt`](examples/property-fee-pricing-ppt/)。智能体读到一份开放式输入（主题：物业费定价；受众：物业管理人员 + 物业委员会；26 页；黑白温馨风），先确定大纲，再产出符合风格规范的逐页素材计划。每一页以语义化的 HTML 方式构造，而不是直接出整页大图：文案、版式、配图、图标、需要的数据图表都是分槽位规划的。素材按槽位生成或选型，并由 VLM 对照页面意图做质检；每页 HTML 渲染出来后再走一轮评审与按需改写，保证用语和视觉一致性。最后把分页截图合成 PPTX，分页 HTML 也保留下来，便于直接在浏览器里预览或继续修改。这个样例展示了 `sn-ppt-standard` 在一份偏文本、长篇幅的方案稿上如何在每一页都遵守同一套受众和配色约束。
 
 - 依赖技能：[`sn-ppt-entry`](skills/sn-ppt-entry/SKILL.md)、[`sn-ppt-standard`](skills/sn-ppt-standard/SKILL.md)
+
+## 社区与第三方体验入口
+
+如果你想先快速体验单个 skill、再决定是否搭建完整本地环境，也可以先试试下面这些社区 / 第三方入口。
+
+> 这些链接并非由本仓库官方维护，不属于 SenseNova-Skills 的官方支持范围。具体可用性、账号要求与平台条款请以对应提供方为准。
+
+- [`sn-infographic`（ClawMama / Telegram / WhatsApp）](https://app.clawmama.run/skills/3k6s9d/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_opensensenova_sensenova_skills_sn_infographic) — 适合先低门槛体验一次信息图生成工作流。
 
 ## 常见问题
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -36,6 +36,14 @@ SenseNova 系列模型可直接接入 [OpenClaw](https://openclaw.ai/)、[hermes
 
 > 👉 立即体验：[xiaohuanxiong.com](https://office.xiaohuanxiong.com/home)
 
+## 社区与第三方体验入口
+
+如果你想先快速体验单个 skill、再决定是否搭建完整本地环境，也可以先试试下面这些社区 / 第三方入口。
+
+> 这些链接并非由本仓库官方维护，不属于 SenseNova-Skills 的官方支持范围。具体可用性、账号要求与平台条款请以对应提供方为准。
+
+- [`sn-infographic`（ClawMama / Telegram / WhatsApp）](https://app.clawmama.run/skills/3k6s9d/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_opensensenova_sensenova_skills_sn_infographic) — 适合先低门槛体验一次信息图生成工作流。
+
 ## 如何使用
 
 本仓库的 skill 需要配合支持 [Agent Skills](https://agentskills.io/) 规范的智能体使用。


### PR DESCRIPTION
## Summary
- add a dedicated third-party quick-try section to the English README
- mirror the same community entry-point section in README_CN.md
- clarify that these links are community / third-party maintained and separate from the official support surface

## Related
- addresses #136

## Testing
- not run (docs only)