### PR TITLE
fix: report malformed caption inputs as JSON

### DIFF
--- a/skills/sn-ppt-entry/scripts/caption_images.py
+++ b/skills/sn-ppt-entry/scripts/caption_images.py
@@ -81,6 +81,14 @@ def _caption_one(vlm, image_path: Path) -> tuple[str | None, str | None]:
     return out.strip(), None
 
 
+def _load_json_file(path: Path) -> tuple[object | None, str | None]:
+    """Load one input file, returning a user-facing error for invalid JSON."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON in {path}: {exc}"
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--deck-dir", type=Path, required=True)
@@ -93,8 +101,13 @@ def main(argv: list[str] | None = None) -> int:
     raw_path = deck / "raw_documents.json"
     info_path = deck / "info_pack.json"
 
-    raw = json.loads(raw_path.read_text(encoding="utf-8")) if raw_path.exists() else None
-    info = json.loads(info_path.read_text(encoding="utf-8")) if info_path.exists() else None
+    raw, raw_error = _load_json_file(raw_path) if raw_path.exists() else (None, None)
+    info, info_error = _load_json_file(info_path) if info_path.exists() else (None, None)
+
+    load_error = raw_error or info_error
+    if load_error:
+        print(json.dumps({"status": "failed", "error": load_error}, ensure_ascii=False))
+        return 1
 
     if raw is None and info is None:
         print(json.dumps({"status": "failed", "error": "neither raw_documents.json nor info_pack.json found"},

--- a/tests/test_caption_images.py
+++ b/tests/test_caption_images.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CAPTION_SCRIPT = REPOSITORY_ROOT / "skills/sn-ppt-entry/scripts/caption_images.py"
+
+
+class CaptionImagesTest(unittest.TestCase):
+    def test_reports_malformed_input_as_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            deck_dir = Path(temp_dir)
+            (deck_dir / "raw_documents.json").write_text(
+                '{"documents": [{', encoding="utf-8"
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(CAPTION_SCRIPT), "--deck-dir", str(deck_dir)],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIn("raw_documents.json", payload["error"])
+        self.assertIn("invalid JSON", payload["error"])
+        self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes: Running caption_images.py with a truncated raw_documents.json exits with an unhandled JSONDecodeError on stderr and no machine-readable status on stdout.
- Root cause: The script called json.loads directly for both deck input files before its structured failure handling, so malformed persisted input escaped main instead of being converted to the documented failed status response.

Closes #145.

## Regression evidence

- Before: `python3 -m unittest -v tests/test_caption_images.py` exited `1`

- After: `python3 -m unittest -v tests/test_caption_images.py` exited `0`

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`
- `node --test tests/*.test.mjs`
- `python3 -m py_compile skills/sn-ppt-entry/scripts/caption_images.py tests/test_caption_images.py`
- `git diff --cached --check`

## Scope

- 2 files changed, +52 / -2 lines
