### PR TITLE
feat(sn-image-base): update Sensenova client to disable watermark by default

### DIFF
--- a/skills/sn-image-base/SKILL.md
+++ b/skills/sn-image-base/SKILL.md
@@ -59,6 +59,8 @@ Image generation tool that calls the text-to-image-no-enhance API.
 | `--insecure` | flag | `False` | Disable TLS verification |
 | `--save-path` | Path | Auto-generated | Save path |
 
+SenseNova U1 Fast requests explicitly send `watermark=false` by default so generated images have no watermark. This feature is currently in free public beta and may become paid.
+
 ### sn-image-recognize
 
 Image recognition tool that uses VLM (Vision Language Model) to analyze image content. Supports multiple image inputs.

--- a/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
@@ -288,6 +288,7 @@ class SensenovaText2ImageClient(T2IBaseClient):
             # "n": 1,
             "response_format": response_format,
             "output_format": output_format,
+            "watermark": False,
             **kwargs,
         }
         return payload


### PR DESCRIPTION
* Added note in SKILL.md about SenseNova U1 Fast requests sending `watermark=false` by default.
* Updated SensenovaText2ImageClient to include `"watermark": False` in the payload for image generation requests.

This feature is currently free for [SenseNova U1 Fast](https://platform.sensenova.cn/docs).