### PR TITLE
feat(sn-search-academic): add SSRN search source

### DIFF
--- a/skills/sn-search-academic/SKILL.md
+++ b/skills/sn-search-academic/SKILL.md
@@ -81,6 +81,7 @@ python3 scripts/search.py <query> [选项]
 - `semantic`
 - `google_scholar`
 - `pubmed`
+- `ssrn`
 - `wikipedia`
 
 示例：
@@ -89,6 +90,7 @@ python3 scripts/search.py <query> [选项]
 python3 scripts/search.py "retrieval augmented generation" --limit 5
 python3 scripts/search.py "diffusion model" --source arxiv,semantic --category cs.CV --limit 5
 python3 scripts/search.py "阿尔茨海默病 多模态诊断" --source pubmed,wikipedia --lang zh --limit 5
+python3 scripts/search.py "open source governance" --source ssrn --limit 10
 python3 scripts/search.py "agentic memory" --source all --limit 8 --output results/search.json
 ```
 
@@ -194,6 +196,7 @@ CLI 输出的顶层不包含 `items`，论文条目在 `source_results[*].items`
 - 通用：`title`、`abstract`、`snippet`、`url`、`citation_count`、`doi`
 - arXiv：`arxiv_id`、`pdf_url`、`categories`
 - Semantic Scholar：`paper_id`、`venue`、`year`
+- SSRN：`doi`、`year`、`publication_date`、`publisher`、`container`（`container` 为 SSRN working paper 系列名称，如 "SSRN Electronic Journal"）
 - PubMed：`pmid`、`pmc_id`、`journal`、`pub_date`
 - Wikipedia：`page_id`、`word_count`、`section_title`
 

--- a/skills/sn-search-academic/references/search.md
+++ b/skills/sn-search-academic/references/search.md
@@ -46,12 +46,13 @@ python3 scripts/search.py "NSA" \
 - `semantic`
 - `google_scholar`
 - `pubmed`
+- `ssrn`
 - `wikipedia`
 
 `--source all` 等价于：
 
 ```text
-arxiv,semantic,google_scholar,pubmed,wikipedia
+arxiv,semantic,google_scholar,pubmed,ssrn,wikipedia
 ```
 
 ## Provider 回退链
@@ -78,6 +79,7 @@ arxiv,semantic,google_scholar,pubmed,wikipedia
 
 - `google_scholar` -> `google_scholar_search.py`
 - `pubmed` -> `pubmed_search.py`
+- `ssrn` -> `ssrn_search.py`
 - `wikipedia` -> `wikipedia_search.py`
 
 ## 参数分发规则
@@ -178,6 +180,7 @@ CLI stdout 和 `--output` 文件使用同一份输出格式。
 - Semantic Scholar: `paper_id`, `doi`, `arxiv_id`, `venue`, `year`
 - Google Scholar: `scholar_id`, `cited_by_url`, `pdf_url`
 - PubMed: `pmid`, `pmc_id`, `journal`, `pub_date`, `doi`
+- SSRN: `doi`, `year`, `publication_date`, `publisher`, `container`
 - Wikipedia: `page_id`, `word_count`, `timestamp`, `section_title`
 
 ## 去重规则
@@ -190,6 +193,7 @@ CLI stdout 和 `--output` 文件使用同一份输出格式。
 - `semantic`: `paper_id`, `doi`, `arxiv_id`, `url`, `title`
 - `google_scholar`: `scholar_id`, `doi`, `url`, `title`
 - `pubmed`: `pmid`, `doi`, `pmc_id`, `url`, `title`
+- `ssrn`: `doi`, `url`, `title`
 - `wikipedia`: `page_id`, `url`, `title`
 
 ## Python API

--- a/skills/sn-search-academic/scripts/search.py
+++ b/skills/sn-search-academic/scripts/search.py
@@ -36,7 +36,7 @@ class ProviderConfig(NamedTuple):
     lang_kwarg: str | None = None
 
 
-DEFAULT_SOURCES = ["arxiv", "semantic", "google_scholar", "pubmed", "wikipedia"]
+DEFAULT_SOURCES = ["arxiv", "semantic", "google_scholar", "pubmed", "wikipedia", "ssrn"]
 
 PROVIDER_GROUPS: dict[str, list[ProviderConfig]] = {
     "arxiv": [
@@ -57,6 +57,9 @@ PROVIDER_GROUPS: dict[str, list[ProviderConfig]] = {
     "pubmed": [
         ProviderConfig("pubmed_search", "pubmed", "pubmed"),
     ],
+    "ssrn": [
+        ProviderConfig("ssrn_search", "ssrn", "ssrn"),
+    ],
     "wikipedia": [
         ProviderConfig("wikipedia_search", "wikipedia", "wikipedia", lang_kwarg="lang"),
     ],
@@ -68,6 +71,7 @@ IDENTITY_FIELDS: dict[str, tuple[str, ...]] = {
     "google_scholar": ("scholar_id", "doi", "url", "title"),
     "pubmed": ("pmid", "doi", "pmc_id", "url", "title"),
     "wikipedia": ("page_id", "url", "title"),
+    "ssrn": ("doi", "url", "title"),
 }
 
 

--- a/skills/sn-search-academic/scripts/ssrn_search.py
+++ b/skills/sn-search-academic/scripts/ssrn_search.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""SSRN (Social Science Research Network) search via CrossRef API.
+
+SSRN is behind Cloudflare, so direct API access is blocked.
+But SSRN assigns DOIs to all papers (prefix 10.2139/ssrn.*), which are
+indexed by CrossRef. This script searches CrossRef and filters for SSRN
+papers.
+
+IMPORTANT: SSRN working papers have NO published-date in CrossRef — they use
+'created' or 'deposited' date. The --days filter uses 'from-deposit-date'.
+
+Usage:
+    python3 ssrn_search.py "open source governance" --limit 20
+    python3 ssrn_search.py "institutional economics" --limit 10 --days 30
+"""
+
+import argparse, json, sys, urllib.request, urllib.parse
+
+CROSSREF_BASE = "https://api.crossref.org/works"
+
+
+def search(query: str, limit: int = 20, days: int | None = None) -> list[dict]:
+    """Search SSRN papers via CrossRef, filtering for DOI prefix 10.2139/ssrn.*."""
+    params = {
+        "query": query,
+        "rows": min(limit * 3, 100),  # SSRN results are sparse; fetch more
+        "sort": "relevance",
+        "order": "desc",
+    }
+    if days:
+        from datetime import datetime, timedelta
+        cutoff = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+        params["filter"] = f"from-deposit-date:{cutoff}"  # SSRN uses deposit-date
+
+    url = f"{CROSSREF_BASE}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "OpenSourceWay/1.0 (mailto:opensourceway@example.com)",
+            "Accept": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}, indent=2))
+        sys.exit(1)
+
+    items = data.get("message", {}).get("items", [])
+    ssrn_items = []
+
+    for item in items:
+        doi = (item.get("DOI") or "").strip()
+        is_ssrn = doi.startswith("10.2139/ssrn")
+
+        if not is_ssrn:
+            urls = [l.get("URL", "") for l in item.get("link", [])]
+            publisher = (item.get("publisher") or "").lower()
+            is_ssrn = any("ssrn.com" in u.lower() for u in urls) or "ssrn" in publisher
+
+        if not is_ssrn:
+            continue
+
+        # SSRN working papers use 'created' or 'deposited' (no published-* fields)
+        date_parts = []
+        for key in ("created", "deposited", "published-online", "published-print"):
+            dp = item.get(key, {}).get("date-parts", [[]])
+            if dp and dp[0] and dp[0][0]:
+                date_parts = dp[0]
+                break
+
+        ssrn_items.append({
+            "title": (item.get("title", [""]))[0],
+            "doi": doi,
+            "url": f"https://doi.org/{doi}" if doi else "",
+            "authors": [f"{a.get('given','')} {a.get('family','')}".strip()
+                        for a in item.get("author", [])
+                        if a.get("given") or a.get("family")],
+            "year": date_parts[0] if date_parts else None,
+            "publication_date": "-".join(str(p) for p in date_parts) if date_parts else "",
+            "publisher": item.get("publisher", ""),
+            "container": (item.get("container-title", [""]))[0] if item.get("container-title") else "",
+            "abstract": (item.get("abstract") or "")[:500],
+        })
+
+    ssrn_items.sort(key=lambda x: x["year"] or 0, reverse=True)
+    return ssrn_items[:limit]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search SSRN papers via CrossRef")
+    parser.add_argument("query", help="Search query")
+    parser.add_argument("--limit", type=int, default=20, help="Max results")
+    parser.add_argument("--days", type=int, help="Only papers deposited in last N days")
+    args = parser.parse_args()
+
+    results = search(args.query, args.limit, args.days)
+    print(json.dumps({
+        "success": True,
+        "query": args.query,
+        "provider": "ssrn (via CrossRef)",
+        "count": len(results),
+        "items": results,
+    }, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add SSRN (Social Science Research Network) as a new `--source ssrn` provider to `sn-search-academic`.

## Motivation

SSRN is the primary repository for working papers in institutional economics, law and economics, and management — journals like JIE, JLE, and Research Policy. arXiv does not cover these. For institutional economics research (the core focus of Open Source Way daily news), SSRN is the only source that indexes unpublished working papers in these fields.

## Changes

- **New script**: `skills/sn-search-academic/scripts/ssrn_search.py` — searches SSRN papers via CrossRef DOI prefix `10.2139/ssrn.*`. SSRN is behind Cloudflare, but its papers are indexed by CrossRef with stable DOIs.
- **Unified entry point**: register `ssrn` in `search.py` (`DEFAULT_SOURCES`, `PROVIDER_GROUPS`, `IDENTITY_FIELDS`).
- **Date fix**: SSRN working papers have no `published-date` in CrossRef — use `deposited`/`created` timestamps and `from-deposit-date` filter.

## Usage

```bash
# Direct
python3 scripts/ssrn_search.py "open source governance" --limit 20 --days 30

# Unified entry
python3 scripts/search.py "institutional economics" --source ssrn --limit 20
```

## Verification

- `--source ssrn` returns 5 SSRN papers for "open source governance" in last 30 days
- Includes institutional economics papers directly relevant to open source governance (e.g. "Cost-Driven Governance in Open-Source AI Innovation Commons")
- Unified `search.py` entry point tested and functional