### PR TITLE
feat(sn-image-base): update default image model u1-fast → u1.5-lite

### DIFF
--- a/skills/sn-image-base/README.md
+++ b/skills/sn-image-base/README.md
@@ -44,7 +44,7 @@ SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_API_KEY="<sensenova-token-plan-api-key>"
 
 # Optional model overrides
-SN_IMAGE_GEN_MODEL="sensenova-u1-fast"   # or other image generation models available in the SenseNova Token Plan
+SN_IMAGE_GEN_MODEL="sensenova-u1.5-lite"   # or other image generation models available in the SenseNova Token Plan
 SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ```
 
@@ -86,7 +86,7 @@ Full configuration for image generation:
 | `SN_BASE_URL` | Global base URL used when capability-specific base URLs are unset | `""` |
 | `SN_IMAGE_GEN_API_KEY` | Optional image-generation-only API key override | `SN_API_KEY` |
 | `SN_IMAGE_GEN_MODEL_TYPE` | The type of image generation model to use | `"sensenova"` |
-| `SN_IMAGE_GEN_MODEL` | The name of the image generation model to use | `"sensenova-u1-fast"` |
+| `SN_IMAGE_GEN_MODEL` | The name of the image generation model to use | `"sensenova-u1.5-lite"` |
 | `SN_IMAGE_GEN_BASE_URL` | The base URL for the image generation API | `SN_BASE_URL`, then `"https://token.sensenova.cn/v1"` |
 
 The default values are recommended for the [SenseNova](https://platform.sensenova.cn/).
@@ -122,7 +122,7 @@ To use non-default image generation models, please:
 
     ```ini
     # (Default) For [SenseNova](https://platform.sensenova.cn/)
-    SN_IMAGE_GEN_MODEL="sensenova-u1-fast"
+    SN_IMAGE_GEN_MODEL="sensenova-u1.5-lite"
     # For Google's Nano Banana model API
     SN_IMAGE_GEN_MODEL="gemini-3.1-flash-image-preview"
     # For OpenAI's image generation API

--- a/skills/sn-image-base/README_CN.md
+++ b/skills/sn-image-base/README_CN.md
@@ -44,7 +44,7 @@ SN_BASE_URL="https://token.sensenova.cn/v1"
 SN_API_KEY="<sensenova-token-plan-api-key>"
 
 # 可选模型覆盖
-SN_IMAGE_GEN_MODEL="sensenova-u1-fast"   # 或 Token Plan 中可用的其他图像生成模型
+SN_IMAGE_GEN_MODEL="sensenova-u1.5-lite"   # 或 Token Plan 中可用的其他图像生成模型
 SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 ```
 
@@ -88,7 +88,7 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 | `SN_BASE_URL` | 所有能力共用的全局基础 URL | `""` |
 | `SN_IMAGE_GEN_API_KEY` | 可选的图像生成专用 API key 覆盖 | `SN_API_KEY` |
 | `SN_IMAGE_GEN_MODEL_TYPE` | 图像生成模型类型 | `"sensenova"` |
-| `SN_IMAGE_GEN_MODEL` | 图像生成模型名 | `"sensenova-u1-fast"` |
+| `SN_IMAGE_GEN_MODEL` | 图像生成模型名 | `"sensenova-u1.5-lite"` |
 | `SN_IMAGE_GEN_BASE_URL` | 图像生成 API 的基础 URL | `SN_BASE_URL`，然后 `"https://token.sensenova.cn/v1"` |
 
 默认值适用于 [SenseNova](https://platform.sensenova.cn/)。
@@ -124,7 +124,7 @@ SN_CHAT_MODEL="sensenova-6.7-flash-lite"
 
     ```ini
     # （默认）用于 [SenseNova](https://platform.sensenova.cn/)
-    SN_IMAGE_GEN_MODEL="sensenova-u1-fast"
+    SN_IMAGE_GEN_MODEL="sensenova-u1.5-lite"
     # 用于 Google Nano Banana 模型 API
     SN_IMAGE_GEN_MODEL="gemini-3.1-flash-image-preview"
     # 用于 OpenAI 图像生成 API

--- a/skills/sn-image-base/scripts/sn_image_base/configs.py
+++ b/skills/sn-image-base/scripts/sn_image_base/configs.py
@@ -100,7 +100,7 @@ class Configs:
     SN_IMAGE_GEN_MODEL_TYPE: Annotated[
         Literal["sensenova", "nano-banana", "openai-image"], Field("SN_IMAGE_GEN_MODEL_TYPE")
     ] = "sensenova"
-    SN_IMAGE_GEN_MODEL: Annotated[str, Field("SN_IMAGE_GEN_MODEL")] = "sensenova-u1-fast"
+    SN_IMAGE_GEN_MODEL: Annotated[str, Field("SN_IMAGE_GEN_MODEL")] = "sensenova-u1.5-lite"
 
     # chat runtime shared by text and vision commands; command-specific
     # SN_TEXT_* / SN_VISION_* values override these defaults.

--- a/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
+++ b/skills/sn-image-base/scripts/sn_image_base/generation/sensenova.py
@@ -273,7 +273,7 @@ class SensenovaText2ImageClient(T2IBaseClient):
 
         Example:
         {
-            "model": "sensenova-u1-fast",
+            "model": "sensenova-u1.5-lite",
             "prompt": "A cat wearing a hat",
             "size": "1024x1024",
             "response_format": "url",


### PR DESCRIPTION
Default image generation model updated from sensenova-u1-fast to sensenova-u1.5-lite.

4 files changed: configs.py default, sensenova.py docstring, README.md, README_CN.md.

Tested: generation confirmed working (2K, 35s, high quality architectural render).